### PR TITLE
Experimental styling

### DIFF
--- a/Barik/AppDelegate.swift
+++ b/Barik/AppDelegate.swift
@@ -5,6 +5,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var menuBarPanel: NSPanel?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        if let error = ConfigManager.shared.initError {
+            showFatalConfigError(message: error)
+            return
+        }
+        
         // Show "What's New" banner if the app version is outdated
         if !VersionChecker.isLatestVersion() {
             VersionChecker.updateVersionFile()
@@ -65,5 +70,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         newPanel.contentView = NSHostingView(rootView: hostingRootView)
         newPanel.orderFront(nil)
         panel = newPanel
+    }
+    
+    private func showFatalConfigError(message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Configuration Error"
+        alert.informativeText = "\(message)\n\nPlease double check ~/.barik-config.toml and try again."
+        alert.alertStyle = .critical
+        alert.addButton(withTitle: "Quit")
+        
+        alert.runModal()
+        NSApplication.shared.terminate(nil)
     }
 }

--- a/Barik/AppDelegate.swift
+++ b/Barik/AppDelegate.swift
@@ -13,7 +13,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     name: Notification.Name("ShowWhatsNewBanner"), object: nil)
             }
         }
-
+        
         MenuBarPopup.setup()
         setupPanels()
 

--- a/Barik/Config/ConfigManager.swift
+++ b/Barik/Config/ConfigManager.swift
@@ -95,6 +95,9 @@ final class ConfigManager: ObservableObject {
 
             [popup.default.time]
             view-variant = "box"
+            
+            [background]
+            enabled = true
             """
         try defaultTOML.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Barik/Config/ConfigManager.swift
+++ b/Barik/Config/ConfigManager.swift
@@ -6,6 +6,8 @@ final class ConfigManager: ObservableObject {
     static let shared = ConfigManager()
 
     @Published private(set) var config = Config()
+    @Published private(set) var initError: String?
+    
     private var fileWatchSource: DispatchSourceFileSystemObject?
     private var fileDescriptor: CInt = -1
     private var configFilePath: String?
@@ -29,6 +31,7 @@ final class ConfigManager: ObservableObject {
                 try createDefaultConfig(at: path1)
                 chosenPath = path1
             } catch {
+                initError = "Error creating default config: \(error.localizedDescription)"
                 print("Error when creating default config:", error)
                 return
             }
@@ -50,6 +53,7 @@ final class ConfigManager: ObservableObject {
                 self.config = Config(rootToml: rootToml)
             }
         } catch {
+            initError = "Error parsing TOML file: \(error.localizedDescription)"
             print("Error when parsing TOML file:", error)
         }
     }

--- a/Barik/Config/ConfigModels.swift
+++ b/Barik/Config/ConfigModels.swift
@@ -263,13 +263,13 @@ struct BackgroundConfig: Decodable {
         height = try container.decodeIfPresent(BackgroundHeight.self, forKey: .height)
     }
     
-    func resolveHeight() -> Float? {
+    func resolveHeight() -> CGFloat? {
         guard let height = height else { return nil }
         switch height {
         case .menuBar:
-            return NSApplication.shared.mainMenu.map({ Float($0.menuBarHeight) }) ?? 0
+            return NSApplication.shared.mainMenu.map({ CGFloat($0.menuBarHeight) }) ?? 0
         case .float(let value):
-            return value
+            return CGFloat(value)
         }
     }
 }

--- a/Barik/Config/ConfigModels.swift
+++ b/Barik/Config/ConfigModels.swift
@@ -5,12 +5,14 @@ struct RootToml: Decodable {
     var yabai: YabaiConfig?
     var aerospace: AerospaceConfig?
     var widgets: WidgetsSection
+    var background: BackgroundConfig
 
     init() {
         self.theme = nil
         self.yabai = nil
         self.aerospace = nil
         self.widgets = WidgetsSection(displayed: [], others: [:])
+        self.background = BackgroundConfig(enabled: false, height: nil)
     }
 }
 
@@ -238,4 +240,9 @@ struct AerospaceConfig: Decodable {
             self.path = "/opt/homebrew/bin/aerospace"
         }
     }
+}
+
+struct BackgroundConfig: Decodable {
+    let enabled: Bool
+    let height: Int?
 }

--- a/Barik/Constants.swift
+++ b/Barik/Constants.swift
@@ -3,4 +3,5 @@ import CoreFoundation
 struct Constants {
     static let menuBarHeight = CGFloat(55)
     static let menuBarPopupAnimationDurationInMilliseconds = 350
+    static let menuBarHorizontalPadding = CGFloat(25)
 }

--- a/Barik/MenuBarPopup/MenuBarPopupView.swift
+++ b/Barik/MenuBarPopup/MenuBarPopupView.swift
@@ -4,6 +4,9 @@ struct MenuBarPopupView<Content: View>: View {
     let content: Content
     let isPreview: Bool
 
+    @ObservedObject var configManager = ConfigManager.shared
+    var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
+
     @State private var contentHeight: CGFloat = 0
     @State private var viewFrame: CGRect = .zero
     @State private var animationValue: Double = 0.01
@@ -31,7 +34,7 @@ struct MenuBarPopupView<Content: View>: View {
             content
                 .background(Color.black)
                 .cornerRadius(((1.0 - animationValue) * 1) + 40)
-                .padding(.top, Constants.menuBarHeight)
+                .padding(.top, foregroundHeight + 5)
                 .offset(x: computedOffset, y: computedYOffset)
                 .shadow(radius: 30)
                 .blur(radius: (1.0 - (0.1 + 0.9 * animationValue)) * 20)

--- a/Barik/Utils/ExperimentalConfigurationModifier.swift
+++ b/Barik/Utils/ExperimentalConfigurationModifier.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+private struct ExperimentalConfigurationModifier: ViewModifier {
+    @ObservedObject var configManager = ConfigManager.shared
+    var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
+    
+    let horizontalPadding: CGFloat
+    let cornerRadius: CGFloat
+    
+    func body(content: Content) -> some View {
+        Group {
+            if !configManager.config.experimental.foreground.widgetsBackground.displayed {
+                content
+            } else {
+                content
+                    .frame(height: foregroundHeight < 45 ? 30 : 38)
+                    .padding(.horizontal, foregroundHeight < 45 && horizontalPadding != 15 ? 0 :
+                                foregroundHeight < 30 ? 0 : horizontalPadding
+                    )
+                    .background(configManager.config.experimental.foreground.widgetsBackground.blur)
+                    .cornerRadius(foregroundHeight < 30 ? 0 : cornerRadius)
+                    .overlay(
+                        foregroundHeight < 30 ? nil :
+                            Capsule().stroke(Color.noActive, lineWidth: 1)
+                    )
+            }
+        }.scaleEffect(foregroundHeight < 25 ? 0.9 : 1, anchor: .leading)
+    }
+}
+
+extension View {
+    func experimentalConfiguration(
+        horizontalPadding: CGFloat = 15,
+        cornerRadius: CGFloat
+    ) -> some View {
+        self.modifier(ExperimentalConfigurationModifier(
+            horizontalPadding: horizontalPadding,
+            cornerRadius: cornerRadius
+        ))
+    }
+}

--- a/Barik/Views/BackgroundView.swift
+++ b/Barik/Views/BackgroundView.swift
@@ -18,6 +18,6 @@ struct BackgroundView: View {
             .background(.regularMaterial)
             .preferredColorScheme(theme)
             .opacity(configManager.config.rootToml.background.enabled ? 1 : 0)
-            .frame(height: configManager.config.rootToml.background.resolveHeight().map { CGFloat($0) })
+            .frame(height: configManager.config.rootToml.background.resolveHeight())
     }
 }

--- a/Barik/Views/BackgroundView.swift
+++ b/Barik/Views/BackgroundView.swift
@@ -3,21 +3,36 @@ import SwiftUI
 struct BackgroundView: View {
     @ObservedObject var configManager = ConfigManager.shared
 
-    var body: some View {
-        let theme: ColorScheme? =
+    private func spacer(_ geometry: GeometryProxy) -> some View {
+        let theme: ColorScheme? = {
             switch configManager.config.rootToml.theme {
-            case "dark":
-                .dark
-            case "light":
-                .light
-            default:
-                .none
+            case "dark": return .dark
+            case "light": return .light
+            default: return nil
             }
+        }()
         
-        Spacer()
-            .background(.regularMaterial)
+        let height = configManager.config.experimental.background.resolveHeight()
+        
+        return Color.clear
+            .frame(height: height ?? geometry.size.height)
             .preferredColorScheme(theme)
-            .opacity(configManager.config.rootToml.background.enabled ? 1 : 0)
-            .frame(height: configManager.config.rootToml.background.resolveHeight())
+        
+    }
+    
+    var body: some View {
+        if configManager.config.experimental.background.displayed {
+            GeometryReader { geometry in
+                if configManager.config.experimental.background.black {
+                    spacer(geometry)
+                        .background(.black)
+                        .id("black")
+                } else {
+                    spacer(geometry)
+                        .background(configManager.config.experimental.background.blur)
+                        .id("blur")
+                }
+            }
+        }
     }
 }

--- a/Barik/Views/BackgroundView.swift
+++ b/Barik/Views/BackgroundView.swift
@@ -18,5 +18,6 @@ struct BackgroundView: View {
             .background(.regularMaterial)
             .preferredColorScheme(theme)
             .opacity(configManager.config.rootToml.background.enabled ? 1 : 0)
+            .frame(height: configManager.config.rootToml.background.resolveHeight().map { CGFloat($0) })
     }
 }

--- a/Barik/Views/BackgroundView.swift
+++ b/Barik/Views/BackgroundView.swift
@@ -13,9 +13,10 @@ struct BackgroundView: View {
             default:
                 .none
             }
-
+        
         Spacer()
             .background(.regularMaterial)
             .preferredColorScheme(theme)
+            .opacity(configManager.config.rootToml.background.enabled ? 1 : 0)
     }
 }

--- a/Barik/Views/MenuBarView.swift
+++ b/Barik/Views/MenuBarView.swift
@@ -29,7 +29,8 @@ struct MenuBarView: View {
             }
         }
         .foregroundStyle(Color.foregroundOutside)
-        .frame(height: configManager.config.rootToml.background.resolveHeight())
+        // clamp frame height between 1 and 55
+        .frame(height: min(max(configManager.config.rootToml.background.resolveHeight() ?? Constants.menuBarHeight, 1.0), Constants.menuBarHeight))
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 25)
         .background(.black.opacity(0.001))

--- a/Barik/Views/MenuBarView.swift
+++ b/Barik/Views/MenuBarView.swift
@@ -29,7 +29,7 @@ struct MenuBarView: View {
             }
         }
         .foregroundStyle(Color.foregroundOutside)
-        .frame(height: Constants.menuBarHeight)
+        .frame(height: configManager.config.rootToml.background.resolveHeight())
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 25)
         .background(.black.opacity(0.001))

--- a/Barik/Views/MenuBarView.swift
+++ b/Barik/Views/MenuBarView.swift
@@ -29,7 +29,7 @@ struct MenuBarView: View {
             }
         }
         .foregroundStyle(Color.foregroundOutside)
-        .frame(height: 55)
+        .frame(height: Constants.menuBarHeight)
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 25)
         .background(.black.opacity(0.001))

--- a/Barik/Views/MenuBarView.swift
+++ b/Barik/Views/MenuBarView.swift
@@ -17,7 +17,7 @@ struct MenuBarView: View {
         let items = configManager.config.rootToml.widgets.displayed
 
         HStack(spacing: 0) {
-            HStack(spacing: 15) {
+            HStack(spacing: configManager.config.experimental.foreground.spacing) {
                 ForEach(0..<items.count, id: \.self) { index in
                     let item = items[index]
                     buildView(for: item)
@@ -29,10 +29,9 @@ struct MenuBarView: View {
             }
         }
         .foregroundStyle(Color.foregroundOutside)
-        // clamp frame height between 1 and 55
-        .frame(height: min(max(configManager.config.rootToml.background.resolveHeight() ?? Constants.menuBarHeight, 1.0), Constants.menuBarHeight))
+        .frame(height: max(configManager.config.experimental.foreground.resolveHeight(), 1.0))
         .frame(maxWidth: .infinity)
-        .padding(.horizontal, 25)
+        .padding(.horizontal, configManager.config.experimental.foreground.horizontalPadding)
         .background(.black.opacity(0.001))
         .preferredColorScheme(theme)
     }

--- a/Barik/Widgets/Battery/BatteryWidget.swift
+++ b/Barik/Widgets/Battery/BatteryWidget.swift
@@ -52,6 +52,7 @@ struct BatteryWidget: View {
                 }
             )
         }
+        .experimentalConfiguration(cornerRadius: 15)
         .frame(maxHeight: .infinity)
         .background(.black.opacity(0.001))
         .onTapGesture {

--- a/Barik/Widgets/Network/NetworkWidget.swift
+++ b/Barik/Widgets/Network/NetworkWidget.swift
@@ -25,6 +25,7 @@ struct NetworkWidget: View {
         )
         .contentShape(Rectangle())
         .font(.system(size: 15))
+        .experimentalConfiguration(cornerRadius: 15)
         .frame(maxHeight: .infinity)
         .background(.black.opacity(0.001))
         .onTapGesture {

--- a/Barik/Widgets/NowPlaying/NowPlayingWidget.swift
+++ b/Barik/Widgets/NowPlaying/NowPlayingWidget.swift
@@ -52,19 +52,30 @@ struct NowPlayingWidget: View {
 /// A view that composes the album art and song text into a capsule-shaped content view.
 struct NowPlayingContent: View {
     let song: NowPlayingSong
-
+    @ObservedObject var configManager = ConfigManager.shared
+    var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
+    
     var body: some View {
-        HStack(spacing: 8) {
-            AlbumArtView(song: song)
-            SongTextView(song: song)
+        Group {
+            if foregroundHeight < 38 {
+                HStack(spacing: 8) {
+                    AlbumArtView(song: song)
+                    SongTextView(song: song)
+                }
+            } else {
+                HStack(spacing: 8) {
+                    AlbumArtView(song: song)
+                    SongTextView(song: song)
+                }
+                .padding(.horizontal, foregroundHeight < 45 ? 8 : 12)
+                .frame(height: foregroundHeight < 45 ? 30 : 38)
+                .background(configManager.config.experimental.foreground.widgetsBackground.blur)
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule().stroke(Color.noActive, lineWidth: 1)
+                )
+            }
         }
-        .padding(.horizontal, 12)
-        .frame(height: 38)
-        .background(.ultraThinMaterial)
-        .clipShape(Capsule())
-        .overlay(
-            Capsule().stroke(Color.noActive, lineWidth: 1)
-        )
         .foregroundColor(.foreground)
     }
 }
@@ -139,17 +150,25 @@ struct AlbumArtView: View {
 /// A view that displays the song title and artist.
 struct SongTextView: View {
     let song: NowPlayingSong
+    @ObservedObject var configManager = ConfigManager.shared
+    var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
 
     var body: some View {
+
         VStack(alignment: .leading, spacing: -1) {
-            Text(song.title)
-                .font(.system(size: 11))
-                .fontWeight(.medium)
-                .padding(.trailing, 2)
-            Text(song.artist)
-                .opacity(0.8)
-                .font(.system(size: 10))
-                .padding(.trailing, 2)
+            if foregroundHeight >= 30 {
+                Text(song.title)
+                    .font(.system(size: 11))
+                    .fontWeight(.medium)
+                    .padding(.trailing, 2)
+                Text(song.artist)
+                    .opacity(0.8)
+                    .font(.system(size: 10))
+                    .padding(.trailing, 2)
+            } else {
+                Text(song.artist + " — " + song.title)
+                    .font(.system(size: 12))
+            }
         }
         // Disable animations for text changes.
         .transaction { transaction in

--- a/Barik/Widgets/Spaces/SpacesWidget.swift
+++ b/Barik/Widgets/Spaces/SpacesWidget.swift
@@ -3,12 +3,16 @@ import SwiftUI
 struct SpacesWidget: View {
     @StateObject var viewModel = SpacesViewModel()
 
+    @ObservedObject var configManager = ConfigManager.shared
+    var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
+
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: foregroundHeight < 30 ? 0 : 8) {
             ForEach(viewModel.spaces) { space in
                 SpaceView(space: space)
             }
         }
+        .experimentalConfiguration(horizontalPadding: 5, cornerRadius: 10)
         .animation(.smooth(duration: 0.3), value: viewModel.spaces)
         .foregroundStyle(Color.foreground)
         .environmentObject(viewModel)
@@ -22,6 +26,9 @@ private struct SpaceView: View {
 
     var config: ConfigData { configProvider.config }
     var spaceConfig: ConfigData { config["space"]?.dictionaryValue ?? [:] }
+
+    @ObservedObject var configManager = ConfigManager.shared
+    var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
 
     var showKey: Bool { spaceConfig["show-key"]?.boolValue ?? true }
 
@@ -49,12 +56,16 @@ private struct SpaceView: View {
         }
         .frame(height: 30)
         .background(
-            isFocused
-                ? Color.active
-                : isHovered ? Color.noActive.opacity(0.5) : Color.noActive
+            foregroundHeight < 30 ?
+            (isFocused
+             ? Color.noActive
+             : Color.clear) :
+                (isFocused
+                 ? Color.active
+                 : isHovered ? Color.noActive : Color.noActive)
         )
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .shadow(color: .shadow, radius: 2)
+        .clipShape(RoundedRectangle(cornerRadius: foregroundHeight < 30 ? 0 : 8, style: .continuous))
+        .shadow(color: .shadow, radius: foregroundHeight < 30 ? 0 : 2)
         .transition(.blurReplace)
         .onTapGesture {
             viewModel.switchToSpace(space, needWindowFocus: true)

--- a/Barik/Widgets/Time+Calendar/TimeWidget.swift
+++ b/Barik/Widgets/Time+Calendar/TimeWidget.swift
@@ -52,6 +52,7 @@ struct TimeWidget: View {
                     }
             }
         )
+        .experimentalConfiguration(cornerRadius: 15)
         .frame(maxHeight: .infinity)
         .background(.black.opacity(0.001))
         .monospacedDigit()


### PR DESCRIPTION
```toml
[experimental.background] # settings for blurred background
displayed = true          # display blurred background
height = "default"        # available values: default (stretch to full screen), menu-bar (height like system menu bar), <float> (e.g., 40, 33.5)
blur = 3                  # background type: from 1 to 6 for blur intensity, 7 for black color

[experimental.foreground] # settings for menu bar
height = "default"        # available values: default (55.0), menu-bar (height like system menu bar), <float> (e.g., 40, 33.5)
horizontal-padding = 25   # padding on the left and right corners
spacing = 15              # spacing between widgets
  
[experimental.foreground.widgets-background] # settings for widgets' background
displayed = false                            # wrap widgets in their own background
blur = 3                                     # background type: from 1 to 6 for blur intensity
```