### PR TITLE
fix: sort order above 10 spaces with yabai

### DIFF
--- a/Barik/Widgets/Spaces/SpacesViewModel.swift
+++ b/Barik/Widgets/Spaces/SpacesViewModel.swift
@@ -48,7 +48,11 @@ class SpacesViewModel: ObservableObject {
                 }
                 return
             }
-            let sortedSpaces = spaces.sorted { $0.id < $1.id }
+            let sortedSpaces = spaces.sorted {
+                let lhsInt = Int($0.id) ?? Int.max
+                let rhsInt = Int($1.id) ?? Int.max
+                return lhsInt < rhsInt
+            }
             DispatchQueue.main.async {
                 self.spaces = sortedSpaces
             }

--- a/Barik/Widgets/Spaces/SpacesViewModel.swift
+++ b/Barik/Widgets/Spaces/SpacesViewModel.swift
@@ -51,7 +51,10 @@ class SpacesViewModel: ObservableObject {
             let sortedSpaces = spaces.sorted {
                 let lhsInt = Int($0.id) ?? Int.max
                 let rhsInt = Int($1.id) ?? Int.max
-                return lhsInt < rhsInt
+                // sort for numbers
+                if lhsInt != rhsInt { return lhsInt < rhsInt }
+                // sort by alphabet
+                return $0.id < $1.id
             }
             DispatchQueue.main.async {
                 self.spaces = sortedSpaces


### PR DESCRIPTION
Before

<img width="1213" height="77" alt="image" src="https://github.com/user-attachments/assets/e28a8c43-f3c0-4fff-b545-a1a9d75b5630" />

After

<img width="1229" height="88" alt="image" src="https://github.com/user-attachments/assets/e4963e3c-3cff-4e24-a158-c20f08e9ec5e" />

https://github.com/mocki-toki/barik/issues/65