### PR TITLE
Universal Native Spaces Provider

### DIFF
--- a/Barik.xcodeproj/project.pbxproj
+++ b/Barik.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D481341A2E9C1BC600A8A5E8 /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D48134192E9C1BC600A8A5E8 /* AXSwift */; };
 		F66C98C52D60E35600C3C53C /* TOMLDecoder in Frameworks */ = {isa = PBXBuildFile; productRef = F66C98C42D60E35600C3C53C /* TOMLDecoder */; };
 		F6B514042D6C5F3400DFEB43 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = F6B514032D6C5F3400DFEB43 /* MarkdownUI */; };
 /* End PBXBuildFile section */
@@ -41,6 +42,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D481341A2E9C1BC600A8A5E8 /* AXSwift in Frameworks */,
 				F66C98C52D60E35600C3C53C /* TOMLDecoder in Frameworks */,
 				F6B514042D6C5F3400DFEB43 /* MarkdownUI in Frameworks */,
 			);
@@ -87,6 +89,7 @@
 			packageProductDependencies = (
 				F66C98C42D60E35600C3C53C /* TOMLDecoder */,
 				F6B514032D6C5F3400DFEB43 /* MarkdownUI */,
+				D48134192E9C1BC600A8A5E8 /* AXSwift */,
 			);
 			productName = Barik;
 			productReference = C10E2F8A2D41235900AC957C /* Barik.app */;
@@ -137,6 +140,7 @@
 			packageReferences = (
 				F66C98C32D60E35600C3C53C /* XCRemoteSwiftPackageReference "TOMLDecoder" */,
 				F6B514022D6C5F3400DFEB43 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+				D48134182E9C1BC600A8A5E8 /* XCRemoteSwiftPackageReference "AXSwift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C10E2F8B2D41235900AC957C /* Products */;
@@ -381,6 +385,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		D48134182E9C1BC600A8A5E8 /* XCRemoteSwiftPackageReference "AXSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tmandry/AXSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.3.2;
+			};
+		};
 		F66C98C32D60E35600C3C53C /* XCRemoteSwiftPackageReference "TOMLDecoder" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dduan/TOMLDecoder";
@@ -400,6 +412,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		D48134192E9C1BC600A8A5E8 /* AXSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D48134182E9C1BC600A8A5E8 /* XCRemoteSwiftPackageReference "AXSwift" */;
+			productName = AXSwift;
+		};
 		F66C98C42D60E35600C3C53C /* TOMLDecoder */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F66C98C32D60E35600C3C53C /* XCRemoteSwiftPackageReference "TOMLDecoder" */;

--- a/Barik.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Barik.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "2c1edbb9aa4aed7663501e3338d324c7016302b32182fae733db881bfb22a2dc",
+  "originHash" : "49adbf9d30b623cfff1f1cbca8db1a9a43f88a49632c381f3cea4b0ba84bf61e",
   "pins" : [
+    {
+      "identity" : "axswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tmandry/AXSwift",
+      "state" : {
+        "revision" : "81dcc36aced905d6464cc25e35f8d13184bbf21c",
+        "version" : "0.3.2"
+      }
+    },
     {
       "identity" : "networkimage",
       "kind" : "remoteSourceControl",

--- a/Barik/Utils/AXSInternal.swift
+++ b/Barik/Utils/AXSInternal.swift
@@ -1,0 +1,30 @@
+//==============================================================================
+//
+//  Acknowledgement:
+//  The private `_AXUIElementGetWindow` function signature used in this file
+//  is based on the `extern.h` header file from the yabai window manager
+//  project by koekeishiya.
+//
+//  Source Link: https://github.com/koekeishiya/yabai/blob/1d9eaa5dbea3d1deb29facb499a5c32bd6536d7a/src/misc/extern.h
+//
+//==============================================================================
+
+import Foundation
+import ApplicationServices
+
+final class AXSInternal {
+    
+    @_silgen_name("_AXUIElementGetWindow")
+    private static func _AXUIElementGetWindow(_ element: AXUIElement, _ wid: UnsafeMutablePointer<CGSWindowID>) -> AXError
+    
+    static func getWindowID(for element: AXUIElement) -> CGSWindowID? {
+        var windowID: CGSWindowID = 0
+        let error = _AXUIElementGetWindow(element, &windowID)
+        
+        guard error == .success else {
+            return nil
+        }
+        
+        return windowID
+    }
+}

--- a/Barik/Utils/CGSInternal.swift
+++ b/Barik/Utils/CGSInternal.swift
@@ -1,0 +1,80 @@
+//==============================================================================
+//
+//  Acknowledgement:
+//  The private Core Graphics Services function signatures and type definitions
+//  used in this file are based on the headers curated by the nuikit/cgsinternal
+//  project.
+//
+//  GitHub: https://github.com/nuikit/cgsinternal/
+//
+//==============================================================================
+
+import Foundation
+
+// MARK: - CGS Types
+
+typealias CGSConnectionID = Int
+typealias CGSSpaceID = Int
+typealias CGSWindowID = UInt32
+typealias CGSDirectDisplayID = UInt32
+typealias CGError = Int32
+
+extension CGError {
+    static let success: CGError = 0
+}
+
+// MARK: - CGSInternal Swift Wrapper
+
+final class CGSInternal {
+    
+    // MARK: - Connection Functions
+    
+    @_silgen_name("CGSMainConnectionID")
+    private static func _CGSMainConnectionID() -> CGSConnectionID
+    
+    @_silgen_name("CGSMainDisplayID")
+    private static func _CGSMainDisplayID() -> CGSDirectDisplayID
+    
+    static let mainConnectionID = _CGSMainConnectionID
+    static let mainDisplayID =  _CGSMainDisplayID
+    
+    // MARK: - Space Functions
+    
+    @_silgen_name("CGSGetActiveSpace")
+    private static func _CGSGetActiveSpace(_ cid: CGSConnectionID) -> CGSSpaceID
+    
+    @_silgen_name("CGSCopyManagedDisplaySpaces")
+    private static func _CGSCopyManagedDisplaySpaces(_ cid: CGSConnectionID) -> CFArray?
+    
+    static func getActiveSpace(connection: CGSConnectionID) -> CGSSpaceID { _CGSGetActiveSpace(connection) }
+    
+    static func copyManagedDisplaySpaces(connection: CGSConnectionID) -> [[String: Any]]? {
+        return _CGSCopyManagedDisplaySpaces(connection) as? [[String: Any]]
+    }
+    
+    // MARK: - Window Functions
+    
+    @_silgen_name("CGSCopyWindowsWithOptionsAndTags")
+    private static func _CGSCopyWindowsWithOptionsAndTags(
+        _ cid: CGSConnectionID,
+        _ owner: Int,
+        _ spaces: CFArray,
+        _ options: Int,
+        _ setTags: UnsafeMutablePointer<Int>,
+        _ clearTags: UnsafeMutablePointer<Int>
+    ) -> CFArray?
+    
+    static func copyWindows(connection: CGSConnectionID, spaces: [CGSSpaceID], options: Int = 2) -> [CGSWindowID]? {
+        var setTags = 0
+        var clearTags = 0
+        
+        return _CGSCopyWindowsWithOptionsAndTags(
+            connection,
+            0,
+            spaces as CFArray,
+            options,
+            &setTags,
+            &clearTags
+        ) as? [CGSWindowID]
+    }
+}

--- a/Barik/Widgets/Spaces/Aerospace/AerospaceModels.swift
+++ b/Barik/Widgets/Spaces/Aerospace/AerospaceModels.swift
@@ -33,6 +33,7 @@ struct AeroSpace: SpaceModel {
     typealias WindowType = AeroWindow
     let workspace: String
     var id: String { workspace }
+    var label: String { id }
     var isFocused: Bool = false
     var windows: [AeroWindow] = []
 

--- a/Barik/Widgets/Spaces/Native/NativeControl.swift
+++ b/Barik/Widgets/Spaces/Native/NativeControl.swift
@@ -1,0 +1,253 @@
+import AppKit
+import CoreGraphics
+import AXSwift
+
+final class NativeControl {
+    
+    static func requestAccess() {
+        _ = UIElement.isProcessTrusted(withPrompt: true)
+    }
+    
+    final class Display {
+        let id: CGSDirectDisplayID
+        private let cid: CGSConnectionID
+        
+        lazy private(set) var uuid: String? = {
+            guard let uuid = CGDisplayCreateUUIDFromDisplayID(id)?.takeRetainedValue() else {
+                return nil
+            }
+            return CFUUIDCreateString(nil, uuid) as String?
+        }()
+        
+        static func main() -> Display {
+            return Display(id: CGSInternal.mainDisplayID())
+        }
+        
+        init(
+            id: CGSDirectDisplayID,
+            cid: CGSConnectionID = CGSInternal.mainConnectionID()
+        ) {
+            self.id = id
+            self.cid = cid
+        }
+        
+        // NOTE: The order of the returned `NCSpace` array matches the visual order
+        //   of the spaces in Mission Control. This behavior is derived from the `CGSCopyManagedDisplaySpaces`
+        //   private API, which provides pre-sorted spaces per display.
+        func getSpaces() -> [Space] {
+            guard uuid != nil, let info = cgInfo else { return [] }
+            
+            return info.spaces.compactMap { si -> Space? in
+                guard let spaceID = si.id else { return nil }
+                return Space(id: spaceID, cid: cid)
+            }
+        }
+        
+        func getWindows() -> [Window] {
+            let spaces = getSpaces()
+            if spaces.isEmpty { return [] }
+            
+            let windowIDs = CGSInternal.copyWindows(connection: cid, spaces: spaces.map(\.id)) ?? []
+            return windowIDs.map { Window(id: $0, cid: cid) }
+        }
+        
+        lazy private(set) var cgInfo: CGSInternal.DispalyInfo? = {
+            return CGSInternal.copyManagedDisplaySpaces(connection: cid)?
+                .compactMap({ CGSInternal.DispalyInfo(rawValue: $0) })
+                .first(where: { $0.uuid == uuid })
+        }()
+    }
+    
+    
+    final class Space {
+        let id: CGSSpaceID
+        private let cid: CGSConnectionID
+        
+        static func active(cid: CGSConnectionID = CGSInternal.mainConnectionID()) -> Space {
+            let sid = CGSInternal.getActiveSpace(connection: cid)
+            return Space(id: sid)
+        }
+        
+        init(
+            id: CGSSpaceID,
+            cid: CGSConnectionID = CGSInternal.mainConnectionID()
+        ) {
+            self.id = id
+            self.cid = cid
+        }
+        
+        func getWindows() -> [Window] {
+            let windowIDs = CGSInternal.copyWindows(connection: cid, spaces: [id]) ?? []
+            return windowIDs.map { Window(id: $0, cid: cid) }
+        }
+    }
+    
+    
+    final class Window {
+        let id: CGSWindowID
+        private let cid: CGSConnectionID
+        
+        static func list(
+            of displayID: CGSDirectDisplayID,
+            cid: CGSConnectionID = CGSInternal.mainConnectionID()
+        ) -> [Window] {
+            let display = Display(id: displayID, cid: cid)
+            return display.getWindows()
+        }
+        
+        static func list(
+            of spaceID: CGSSpaceID,
+            cid: CGSConnectionID = CGSInternal.mainConnectionID()
+        ) -> [Window] {
+            let space = Space(id: spaceID, cid: cid)
+            return space.getWindows()
+        }
+        
+        static func focused() -> Window? {
+            guard UIElement.isProcessTrusted(withPrompt: false) else { return nil }
+            guard
+                let axapp: UIElement = try? systemWideElement.attribute(.focusedApplication),
+                let axwin: UIElement = try? axapp.attribute(.focusedWindow),
+                let wid = AXSInternal.getWindowID(for: axwin.element)
+            else { return nil }
+            return Window(id: wid)
+        }
+        
+        init(
+            id: CGSWindowID,
+            cid: CGSConnectionID = CGSInternal.mainConnectionID()
+        ) {
+            self.id = id
+            self.cid = cid
+        }
+        
+        lazy private(set) var app: NSRunningApplication? = {
+            guard let pid = cgInfo?.ownerPID else { return nil }
+            return NSRunningApplication(processIdentifier: pid)
+        }()
+        
+        lazy private(set) var cgInfo: CGSInternal.WindowInfo? = {
+            guard
+                let wlis = CGWindowListCopyWindowInfo(CGWindowListOption.optionIncludingWindow, id) as? [[String: Any]],
+                let raw = wlis.first
+            else { return nil }
+            return CGSInternal.WindowInfo(rawValue: raw)
+        }()
+        
+        lazy private(set) var title: String? = {
+            if let title = cgInfo?.title {
+                return title
+            }
+            
+            guard let e = element else { return nil }
+            return try? e.attribute(.title)
+        }()
+        
+        lazy private(set) var isFullscreen: Bool? = {
+            if let layer = cgInfo?.layer, layer == CGSInternal.WindowInfo.Layer.fullscreen {
+                return true
+            }
+            
+            guard let e = element else { return nil }
+            return try? e.attribute(.fullScreen)
+        }()
+        
+        lazy private var element: UIElement? = {
+            guard UIElement.isProcessTrusted(withPrompt: false) else { return nil }
+            guard
+                let app = app,
+                let wins = try? Application(app)?.windows()
+            else { return nil }
+            
+            return wins.first(where: { AXSInternal.getWindowID(for: $0.element) == id })
+        }()
+    }
+}
+
+
+extension CGSInternal {
+    struct DispalyInfo: RawRepresentable, ExpressibleByDictionaryLiteral {
+        typealias Key = String
+        typealias Value = Any
+        typealias RawValue = [Key: Value]
+        
+        var rawValue: [Key : Value]
+        
+        private enum Keys: String {
+            case Identifier = "Display Identifier"
+            case Spaces = "Spaces"
+        }
+        
+        var uuid: String? { rawValue[Keys.Identifier.rawValue] as? String }
+        var spaces: [SpaceInfo] {
+            guard let raw = rawValue[Keys.Spaces.rawValue] as? [[String: Any]] else { return [] }
+            return raw.compactMap { SpaceInfo(rawValue: $0) }
+        }
+        
+        init?(rawValue: [Key : Value]) {
+            self.rawValue = rawValue
+        }
+        
+        init(dictionaryLiteral elements: (Key, Value)...) {
+            self.rawValue = Dictionary(uniqueKeysWithValues: elements)
+        }
+    }
+    
+    struct SpaceInfo: RawRepresentable, ExpressibleByDictionaryLiteral {
+        typealias Key = String
+        typealias Value = Any
+        typealias RawValue = [Key: Value]
+        
+        var rawValue: [Key : Value]
+        
+        private enum Keys: String {
+            case ID = "id64"
+        }
+        
+        var id: CGSSpaceID? { rawValue[Keys.ID.rawValue] as? CGSSpaceID }
+        
+        init?(rawValue: [Key : Value]) {
+            self.rawValue = rawValue
+        }
+        
+        init(dictionaryLiteral elements: (Key, Value)...) {
+            rawValue = Dictionary(uniqueKeysWithValues: elements)
+        }
+    }
+    
+    struct WindowInfo: RawRepresentable, ExpressibleByDictionaryLiteral {
+        typealias Key = String
+        typealias Value = Any
+        typealias RawValue = [Key: Value]
+        
+        var rawValue: [Key : Value]
+        
+        private enum Keys: String {
+            case Title = "kCGWindowName"
+            case OwnerPID = "kCGWindowOwnerPID"
+            case Layer = "kCGWindowLayer"
+            case IsOnScreen = "kCGWindowIsOnscreen"
+        }
+        
+        /// Layers aren't documented well, so values were found heuristically
+        enum Layer: Int {
+            case base = 0
+            case fullscreen = 26
+        }
+        
+        var title: String? { rawValue[Keys.Title.rawValue] as? String }
+        var ownerPID: pid_t? { rawValue[Keys.OwnerPID.rawValue] as? pid_t }
+        var layer: Layer? {
+            (rawValue[Keys.Layer.rawValue] as? Int).flatMap { Layer(rawValue: $0) }
+        }
+        var isOnScreen: Bool? { rawValue[Keys.IsOnScreen.rawValue] as? Bool }
+        
+        init?(rawValue: [Key : Value]) {
+            self.rawValue = rawValue
+        }
+        
+        init(dictionaryLiteral elements: (String, Value)...) {
+            rawValue = Dictionary(uniqueKeysWithValues: elements)
+        }
+    }
+}

--- a/Barik/Widgets/Spaces/Native/NativeModels.swift
+++ b/Barik/Widgets/Spaces/Native/NativeModels.swift
@@ -1,0 +1,51 @@
+import AppKit
+
+
+struct NativeSpaceWindow: WindowModel {
+    var id: Int
+    var title: String
+    var appName: String?
+    var isFocused: Bool
+    var appIcon: NSImage?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case appName = "app-name"
+        case isFocused = "focused"
+    }
+    
+    init(id: Int, title: String, appName: String?, isFocused: Bool, appIcon: NSImage? = nil) {
+        self.id = id
+        self.title = title
+        self.appName = appName
+        self.isFocused = isFocused
+        self.appIcon = appIcon ?? (appName.flatMap { IconCache.shared.icon(for: $0) })
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        appName = try container.decodeIfPresent(String.self, forKey: .appName)
+        isFocused = try container.decodeIfPresent(Bool.self, forKey: .isFocused) ?? false
+        if let name = appName { appIcon = IconCache.shared.icon(for: name) }
+    }
+}
+
+
+struct NativeSpace: SpaceModel {
+    typealias WindowType = NativeSpaceWindow
+    
+    let id: Int
+    var label: String
+    var isFocused: Bool
+    var windows: [WindowType] = []
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case label
+        case isFocused = "focused"
+    }
+}
+

--- a/Barik/Widgets/Spaces/Native/NativeProvider.swift
+++ b/Barik/Widgets/Spaces/Native/NativeProvider.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwiftUI
+import AppKit
+
+
+class NativeSpaceProvider: SpacesProvider {
+    typealias SpaceType = NativeSpace
+    
+    init() {
+        NativeControl.requestAccess()
+    }
+    
+    func getSpacesWithWindows() -> [NativeSpace]? {
+        let spaces = NativeControl.Display.main().getSpaces()
+        let active = NativeControl.Space.active()
+        
+        let focused = NativeControl.Window.focused()
+        
+        return spaces.enumerated().map { (i, s) in
+            let (windows, isFullscreen) = getWindows(for: s, focused)
+            
+            return NativeSpace(
+                id: s.id,
+                label: isFullscreen ? "↖" : String(i + 1),
+                isFocused: s.id == active.id,
+                windows: windows.map { w in
+                    NativeSpaceWindow(
+                        id: Int(w.id),
+                        title: w.title ?? "",
+                        appName: w.app?.localizedName,
+                        isFocused: w.id == focused?.id,
+                    )
+                }
+            )
+        }.filter { !$0.windows.isEmpty }
+    }
+    
+    private func getWindows(
+        for space: NativeControl.Space,
+        _ focused: NativeControl.Window? = NativeControl.Window.focused(),
+    ) -> ([NativeControl.Window], isFullscreen: Bool) {
+        let (base, full) = space.getWindows()
+            .reduce(into: (
+                base: [NativeControl.Window](),
+                full: [NativeControl.Window]()
+            )) { result, w in
+                switch true {
+                case w.isFullscreen == true:
+                    result.full.append(w)
+                case w.cgInfo?.layer == .base:
+                    result.base.append(w)
+                default:
+                    /// filter out any window that is neither fullscreen nor a base one
+                    break
+                }
+            }
+         
+        return !full.isEmpty
+            ? (full, isFullscreen: true)
+            : (base, isFullscreen: false)
+    }
+}

--- a/Barik/Widgets/Spaces/SpacesModels.swift
+++ b/Barik/Widgets/Spaces/SpacesModels.swift
@@ -1,7 +1,9 @@
 import AppKit
 
-protocol SpaceModel: Identifiable, Equatable, Codable {
+protocol SpaceModel<ID>: Identifiable, Equatable, Codable {
     associatedtype WindowType: WindowModel
+    var id: ID { get }
+    var label: String { get }
     var isFocused: Bool { get set }
     var windows: [WindowType] { get set }
 }
@@ -47,17 +49,13 @@ struct AnyWindow: Identifiable, Equatable {
 
 struct AnySpace: Identifiable, Equatable {
     let id: String
+    let label: String
     let isFocused: Bool
     let windows: [AnyWindow]
 
     init<S: SpaceModel>(_ space: S) {
-        if let aero = space as? AeroSpace {
-            self.id = aero.workspace
-        } else if let yabai = space as? YabaiSpace {
-            self.id = String(yabai.id)
-        } else {
-            self.id = "0"
-        }
+        self.id = String(describing: space.id)
+        self.label = space.label
         self.isFocused = space.isFocused
         self.windows = space.windows.map { AnyWindow($0) }
     }

--- a/Barik/Widgets/Spaces/SpacesViewModel.swift
+++ b/Barik/Widgets/Spaces/SpacesViewModel.swift
@@ -1,92 +1,82 @@
-import AppKit
+import SwiftUI
 import Combine
-import Foundation
 
+@MainActor
 class SpacesViewModel: ObservableObject {
-    @Published var spaces: [AnySpace] = []
-    private var timer: Timer?
-    private var provider: AnySpacesProvider?
+    
+    @Published private(set) var spaces: [AnySpace] = []
+    
+    private let provider: AnySpacesProvider?
+    private var monitoring: Task<Void, Never>?
 
     init() {
-        let runningApps = NSWorkspace.shared.runningApplications.compactMap {
-            $0.localizedName?.lowercased()
-        }
+        defer { startMonitoring() }
+        
+        let runningApps = NSWorkspace.shared.runningApplications.compactMap { $0.localizedName?.lowercased() }
+        
         if runningApps.contains("yabai") {
             provider = AnySpacesProvider(YabaiSpacesProvider())
         } else if runningApps.contains("aerospace") {
             provider = AnySpacesProvider(AerospaceSpacesProvider())
         } else {
-            provider = nil
+            provider = AnySpacesProvider(NativeSpaceProvider())
         }
-        startMonitoring()
     }
-
+        
     deinit {
-        stopMonitoring()
+        monitoring?.cancel()
     }
 
     private func startMonitoring() {
-        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) {
-            [weak self] _ in
-            self?.loadSpaces()
-        }
-        loadSpaces()
-    }
-
-    private func stopMonitoring() {
-        timer?.invalidate()
-        timer = nil
-    }
-
-    private func loadSpaces() {
-        DispatchQueue.global(qos: .background).async {
-            guard let provider = self.provider,
-                let spaces = provider.getSpacesWithWindows()
-            else {
-                DispatchQueue.main.async {
-                    self.spaces = []
-                }
-                return
-            }
-            let sortedSpaces = spaces.sorted { $0.id < $1.id }
-            DispatchQueue.main.async {
-                self.spaces = sortedSpaces
+        monitoring?.cancel()
+        monitoring = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.loadSpaces()
+                try? await Task.sleep(for: .milliseconds(100))
             }
         }
+    }
+
+    private func loadSpaces() async {
+        spaces = await Task.detached { [weak provider] in provider?.getSpacesWithWindows() ?? [] }.value
     }
 
     func switchToSpace(_ space: AnySpace, needWindowFocus: Bool = false) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            self.provider?.focusSpace(
-                spaceId: space.id, needWindowFocus: needWindowFocus)
+        Task.detached(priority: .userInitiated) { [ weak provider ] in
+            provider?.focusSpace(spaceId: space.id, needWindowFocus: needWindowFocus)
         }
     }
 
     func switchToWindow(_ window: AnyWindow) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            self.provider?.focusWindow(windowId: String(window.id))
+        Task.detached(priority: .userInitiated) { [ weak provider ] in
+            provider?.focusWindow(windowId: String(window.id))
         }
     }
 }
 
+
 class IconCache {
+    
     static let shared = IconCache()
+    
     private let cache = NSCache<NSString, NSImage>()
-    private init() {}
+    
     func icon(for appName: String) -> NSImage? {
         if let cached = cache.object(forKey: appName as NSString) {
             return cached
         }
+        
         let workspace = NSWorkspace.shared
-        if let app = workspace.runningApplications.first(where: {
-            $0.localizedName == appName
-        }),
+        guard
+            let app = workspace.runningApplications.first(where: {
+                $0.localizedName == appName
+            }),
             let bundleURL = app.bundleURL
-        {
-            let icon = workspace.icon(forFile: bundleURL.path)
-            cache.setObject(icon, forKey: appName as NSString)
-            return icon
-        }
-        return nil
+        else { return nil }
+        
+        let icon = workspace.icon(forFile: bundleURL.path)
+        cache.setObject(icon, forKey: appName as NSString)
+        
+        return icon
     }
 }

--- a/Barik/Widgets/Spaces/SpacesWidget.swift
+++ b/Barik/Widgets/Spaces/SpacesWidget.swift
@@ -4,6 +4,7 @@ struct SpacesWidget: View {
     @StateObject var viewModel = SpacesViewModel()
 
     @ObservedObject var configManager = ConfigManager.shared
+    
     var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
 
     var body: some View {
@@ -41,7 +42,7 @@ private struct SpaceView: View {
         HStack(spacing: 0) {
             Spacer().frame(width: 10)
             if showKey {
-                Text(space.id)
+                Text(space.label)
                     .font(.headline)
                     .frame(minWidth: 15)
                     .fixedSize(horizontal: true, vertical: false)
@@ -90,7 +91,11 @@ private struct WindowView: View {
 
     var showTitle: Bool { windowConfig["show-title"]?.boolValue ?? true }
     var maxLength: Int { titleConfig["max-length"]?.intValue ?? 50 }
-    var alwaysDisplayAppTitleFor: [String] { titleConfig["always-display-app-name-for"]?.arrayValue?.filter({ $0.stringValue != nil }).map { $0.stringValue! } ?? [] }
+    var alwaysDisplayAppTitleFor: [String] { 
+        titleConfig["always-display-app-name-for"]?.arrayValue?
+            .filter({ $0.stringValue != nil })
+            .map { $0.stringValue! } ?? [] 
+    }
 
     let window: AnyWindow
     let space: AnySpace
@@ -100,10 +105,12 @@ private struct WindowView: View {
     var body: some View {
         let titleMaxLength = maxLength
         let size: CGFloat = 21
-        let sameAppCount = space.windows.filter { $0.appName == window.appName }
-            .count
-        let title = sameAppCount > 1 && !alwaysDisplayAppTitleFor.contains { $0 == window.appName } ? window.title : (window.appName ?? "")
+        let sameAppCount = space.windows.filter { $0.appName == window.appName }.count
+        let title = sameAppCount > 1 && !alwaysDisplayAppTitleFor.contains { $0 == window.appName } 
+            ? window.title 
+            : (window.appName ?? "")
         let spaceIsFocused = space.windows.contains { $0.isFocused }
+        
         HStack {
             ZStack {
                 if let icon = window.appIcon {

--- a/Barik/Widgets/Spaces/Yabai/YabaiModels.swift
+++ b/Barik/Widgets/Spaces/Yabai/YabaiModels.swift
@@ -47,6 +47,7 @@ struct YabaiWindow: WindowModel {
 struct YabaiSpace: SpaceModel {
     typealias WindowType = YabaiWindow
     let id: Int
+    var label: String { String(id) }
     var isFocused: Bool
     var windows: [YabaiWindow] = []
 


### PR DESCRIPTION
<img width="1148" height="564" alt="CleanShot 2025-10-12 at 7  56 45@2x" src="https://github.com/user-attachments/assets/83a11aa3-ce99-418d-a1c6-b92a02db9df9" />

This PR adds a window manager-independent method for reading macOS Spaces. By implementing a ⁠NativeSpaceProvider using private system APIs, the feature is now compatible with any window management setup that utilizes native macOS Spaces, including the default Mission Control.

This should make the project more accessible to users who prefer simpler window management setups over complex, hotkey-based ones.

Note: The current version implements a default, read-only space provider. The logic for switching spaces may be added in a future release.