### PR TITLE
fix: restore now playing widget in default config

### DIFF
--- a/Barik/Barik.entitlements
+++ b/Barik/Barik.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.location</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/Barik/Config/ConfigManager.swift
+++ b/Barik/Config/ConfigManager.swift
@@ -72,6 +72,7 @@ final class ConfigManager: ObservableObject {
             displayed = [ # widgets on menu bar
                 "default.spaces",
                 "spacer",
+                "default.nowplaying",
                 "default.network",
                 "default.battery",
                 "divider",

--- a/Barik/Helpers/SystemUIHelper.swift
+++ b/Barik/Helpers/SystemUIHelper.swift
@@ -4,26 +4,23 @@ import Foundation
 /// Helper for triggering macOS system UI elements
 final class SystemUIHelper {
 
-    /// Opens the macOS Notification Center
+    /// Opens the macOS Notification Center by simulating Ctrl+Option+N keypress
     static func openNotificationCenter() {
-        // Check for Accessibility permission first
-        let trusted = AXIsProcessTrustedWithOptions(
-            [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
-        )
+        // Simulate Ctrl+Option+N keyboard shortcut
+        let keyCode: CGKeyCode = 45  // 'n' key
+        let flags: CGEventFlags = [.maskControl, .maskAlternate]
 
-        guard trusted else {
-            // System will show the prompt automatically
-            return
+        // Create and post key down event
+        if let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true) {
+            keyDown.flags = flags
+            keyDown.post(tap: .cghidEventTap)
         }
 
-        let script = """
-            tell application "System Events"
-                tell process "ControlCenter"
-                    click menu bar item "Clock" of menu bar 1
-                end tell
-            end tell
-            """
-        runAppleScript(script)
+        // Create and post key up event
+        if let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) {
+            keyUp.flags = flags
+            keyUp.post(tap: .cghidEventTap)
+        }
     }
 
     /// Opens the macOS Weather menu bar dropdown

--- a/Barik/Helpers/SystemUIHelper.swift
+++ b/Barik/Helpers/SystemUIHelper.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Foundation
+
+/// Helper for triggering macOS system UI elements
+final class SystemUIHelper {
+
+    /// Opens the macOS Notification Center
+    static func openNotificationCenter() {
+        let script = """
+            tell application "System Events"
+                tell process "ControlCenter"
+                    click menu bar item "Clock" of menu bar 1
+                end tell
+            end tell
+            """
+        runAppleScript(script)
+    }
+
+    /// Opens the macOS Weather menu bar dropdown
+    static func openWeatherDropdown() {
+        let script = """
+            tell application "System Events"
+                tell process "ControlCenter"
+                    try
+                        click menu bar item "Weather" of menu bar 1
+                    on error
+                        -- Weather might not be in menu bar, try to open Weather app instead
+                        tell application "Weather" to activate
+                    end try
+                end tell
+            end tell
+            """
+        runAppleScript(script)
+    }
+
+    /// Opens the Weather app
+    static func openWeatherApp() {
+        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.Weather")!)
+        // Fallback to opening Weather app directly
+        if let weatherURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.weather") {
+            NSWorkspace.shared.open(weatherURL)
+        }
+    }
+
+    /// Runs an AppleScript
+    @discardableResult
+    private static func runAppleScript(_ script: String) -> String? {
+        guard let appleScript = NSAppleScript(source: script) else {
+            return nil
+        }
+        var error: NSDictionary?
+        let result = appleScript.executeAndReturnError(&error)
+        if let error = error {
+            print("AppleScript Error: \(error)")
+            return nil
+        }
+        return result.stringValue
+    }
+}

--- a/Barik/Helpers/SystemUIHelper.swift
+++ b/Barik/Helpers/SystemUIHelper.swift
@@ -6,6 +6,16 @@ final class SystemUIHelper {
 
     /// Opens the macOS Notification Center
     static func openNotificationCenter() {
+        // Check for Accessibility permission first
+        let trusted = AXIsProcessTrustedWithOptions(
+            [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+        )
+
+        guard trusted else {
+            // System will show the prompt automatically
+            return
+        }
+
         let script = """
             tell application "System Events"
                 tell process "ControlCenter"

--- a/Barik/Info.plist
+++ b/Barik/Info.plist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSLocationUsageDescription</key>
+	<string>Barik needs your location to show local weather conditions.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Barik needs your location to show local weather conditions.</string>
+</dict>
 </plist>

--- a/Barik/MenuBarPopup/MenuBarPopup.swift
+++ b/Barik/MenuBarPopup/MenuBarPopup.swift
@@ -72,13 +72,10 @@ class MenuBarPopup {
             DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
                 panel.contentView = NSHostingView(
                     rootView:
-                        ZStack {
-                            MenuBarPopupView(widgetRect: rect) {
-                                content()
-                            }
-                            .position(x: rect.midX)
+                        MenuBarPopupView(widgetRect: rect) {
+                            content()
                         }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                         .id(UUID())
                 )
                 panel.makeKeyAndOrderFront(nil)
@@ -90,13 +87,10 @@ class MenuBarPopup {
         } else {
             panel.contentView = NSHostingView(
                 rootView:
-                    ZStack {
-                        MenuBarPopupView(widgetRect: rect) {
-                            content()
-                        }
-                        .position(x: rect.midX)
+                    MenuBarPopupView(widgetRect: rect) {
+                        content()
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             )
             panel.makeKeyAndOrderFront(nil)
             DispatchQueue.main.async {
@@ -107,13 +101,11 @@ class MenuBarPopup {
     }
 
     static func setup() {
-        guard let screen = NSScreen.main?.visibleFrame else { return }
-        let panelFrame = NSRect(
-            x: 0,
-            y: 0,
-            width: screen.size.width,
-            height: screen.size.height
-        )
+        guard let screen = NSScreen.main else { return }
+
+        // Use full screen frame so the panel covers the entire screen including menu bar area
+        // This ensures consistent positioning regardless of dock position or menu bar configuration
+        let panelFrame = screen.frame
 
         let newPanel = HidingPanel(
             contentRect: panelFrame,

--- a/Barik/MenuBarPopup/MenuBarPopup.swift
+++ b/Barik/MenuBarPopup/MenuBarPopup.swift
@@ -74,7 +74,7 @@ class MenuBarPopup {
                 panel.contentView = NSHostingView(
                     rootView:
                         ZStack {
-                            MenuBarPopupView {
+                            MenuBarPopupView(widgetRect: rect) {
                                 content()
                             }
                             .position(x: rect.midX)
@@ -92,7 +92,7 @@ class MenuBarPopup {
             panel.contentView = NSHostingView(
                 rootView:
                     ZStack {
-                        MenuBarPopupView {
+                        MenuBarPopupView(widgetRect: rect) {
                             content()
                         }
                         .position(x: rect.midX)

--- a/Barik/MenuBarPopup/MenuBarPopupVariantView.swift
+++ b/Barik/MenuBarPopup/MenuBarPopupVariantView.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 
 enum MenuBarPopupVariant: String, Equatable {
-    case box, vertical, horizontal, settings
+    case box, vertical, horizontal, dayView, settings
 }
 
 struct MenuBarPopupVariantView: View {
     private let box: AnyView?
     private let vertical: AnyView?
     private let horizontal: AnyView?
+    private let dayView: AnyView?
     private let settings: AnyView?
 
     var selectedVariant: MenuBarPopupVariant
@@ -22,6 +23,7 @@ struct MenuBarPopupVariantView: View {
         @ViewBuilder box: () -> some View = { EmptyView() },
         @ViewBuilder vertical: () -> some View = { EmptyView() },
         @ViewBuilder horizontal: () -> some View = { EmptyView() },
+        @ViewBuilder dayView: () -> some View = { EmptyView() },
         @ViewBuilder settings: () -> some View = { EmptyView() }
     ) {
         self.selectedVariant = selectedVariant
@@ -30,6 +32,7 @@ struct MenuBarPopupVariantView: View {
         let boxView = box()
         let verticalView = vertical()
         let horizontalView = horizontal()
+        let dayViewView = dayView()
         let settingsView = settings()
 
         self.box = (boxView is EmptyView) ? nil : AnyView(boxView)
@@ -37,6 +40,8 @@ struct MenuBarPopupVariantView: View {
             (verticalView is EmptyView) ? nil : AnyView(verticalView)
         self.horizontal =
             (horizontalView is EmptyView) ? nil : AnyView(horizontalView)
+        self.dayView =
+            (dayViewView is EmptyView) ? nil : AnyView(dayViewView)
         self.settings =
             (settingsView is EmptyView) ? nil : AnyView(settingsView)
     }
@@ -62,6 +67,11 @@ struct MenuBarPopupVariantView: View {
                     variantButton(
                         variant: .horizontal,
                         systemImageName: "rectangle.inset.filled")
+                }
+                if dayView != nil {
+                    variantButton(
+                        variant: .dayView,
+                        systemImageName: "calendar.day.timeline.left")
                 }
                 if settings != nil {
                     variantButton(
@@ -89,6 +99,8 @@ struct MenuBarPopupVariantView: View {
             if let view = vertical { view }
         case .horizontal:
             if let view = horizontal { view }
+        case .dayView:
+            if let view = dayView { view }
         case .settings:
             if let view = settings { view }
         }

--- a/Barik/MenuBarPopup/MenuBarPopupView.swift
+++ b/Barik/MenuBarPopup/MenuBarPopupView.swift
@@ -151,7 +151,7 @@ struct MenuBarPopupView<Content: View>: View {
     }
 
     var computedYOffset: CGFloat {
-        return viewFrame.height / 2
+        return 0
     }
 }
 

--- a/Barik/MenuBarPopup/MenuBarPopupView.swift
+++ b/Barik/MenuBarPopup/MenuBarPopupView.swift
@@ -31,9 +31,10 @@ struct MenuBarPopupView<Content: View>: View {
         }
     }
 
-    // Position popup just below the menu bar
+    // Position popup directly below the Barik menu bar
+    // foregroundHeight is the exact height of the Barik bar, which overlays the system menu bar
     var popupTopPosition: CGFloat {
-        return foregroundHeight + 52
+        return foregroundHeight
     }
 
     var body: some View {
@@ -141,19 +142,25 @@ struct MenuBarPopupView<Content: View>: View {
         .preferredColorScheme(.dark)
     }
 
+    // Calculate X offset to center popup under widget, with edge constraints
     var computedOffset: CGFloat {
         let screenWidth = NSScreen.main?.frame.width ?? 0
-        let W = viewFrame.width
-        let M = viewFrame.midX
-        let newLeft = (M - W / 2) - 20
-        let newRight = (M + W / 2) + 20
+        let contentWidth = viewFrame.width > 0 ? viewFrame.width : 200  // Fallback width
 
-        if newRight > screenWidth {
-            return screenWidth - newRight
-        } else if newLeft < 0 {
-            return -newLeft
+        // Start by centering under the widget
+        var xOffset = widgetRect.midX - contentWidth / 2
+
+        // Constrain to screen edges with 20pt margin
+        let rightEdge = xOffset + contentWidth + 20
+        let leftEdge = xOffset - 20
+
+        if rightEdge > screenWidth {
+            xOffset -= (rightEdge - screenWidth)
+        } else if leftEdge < 0 {
+            xOffset -= leftEdge
         }
-        return 0
+
+        return xOffset
     }
 
     var computedYOffset: CGFloat {

--- a/Barik/MenuBarPopup/MenuBarPopupView.swift
+++ b/Barik/MenuBarPopup/MenuBarPopupView.swift
@@ -6,6 +6,7 @@ struct MenuBarPopupView<Content: View>: View {
     let widgetRect: CGRect
 
     @ObservedObject var configManager = ConfigManager.shared
+    var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
 
     @State private var contentHeight: CGFloat = 0
     @State private var viewFrame: CGRect = .zero
@@ -30,10 +31,9 @@ struct MenuBarPopupView<Content: View>: View {
         }
     }
 
-    // Position popup just below the widget
-    // Simply use widgetRect.maxY (bottom of widget in SwiftUI coords) + small gap
+    // Position popup just below the menu bar
     var popupTopPosition: CGFloat {
-        return widgetRect.maxY + 5
+        return foregroundHeight + 52
     }
 
     var body: some View {
@@ -41,11 +41,10 @@ struct MenuBarPopupView<Content: View>: View {
             content
                 .background(Color.black)
                 .cornerRadius(((1.0 - animationValue) * 1) + 40)
-                .padding(.top, popupTopPosition)
-                .offset(x: computedOffset, y: computedYOffset)
                 .shadow(radius: 30)
                 .blur(radius: (1.0 - (0.1 + 0.9 * animationValue)) * 20)
-                .scaleEffect(x: 0.2 + 0.8 * animationValue, y: animationValue)
+                .scaleEffect(x: 0.2 + 0.8 * animationValue, y: animationValue, anchor: .top)
+                .offset(x: computedOffset, y: popupTopPosition)
                 .opacity(animationValue)
                 .transaction { transaction in
                     if isHideAnimation {

--- a/Barik/MenuBarPopup/MenuBarPopupView.swift
+++ b/Barik/MenuBarPopup/MenuBarPopupView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 struct MenuBarPopupView<Content: View>: View {
     let content: Content
     let isPreview: Bool
+    let widgetRect: CGRect
 
     @ObservedObject var configManager = ConfigManager.shared
-    var foregroundHeight: CGFloat { configManager.config.experimental.foreground.resolveHeight() }
 
     @State private var contentHeight: CGFloat = 0
     @State private var viewFrame: CGRect = .zero
@@ -21,7 +21,8 @@ struct MenuBarPopupView<Content: View>: View {
     private let willChangeContent = NotificationCenter.default.publisher(
         for: .willChangeContent)
 
-    init(isPreview: Bool = false, @ViewBuilder content: () -> Content) {
+    init(widgetRect: CGRect = .zero, isPreview: Bool = false, @ViewBuilder content: () -> Content) {
+        self.widgetRect = widgetRect
         self.content = content()
         self.isPreview = isPreview
         if isPreview {
@@ -29,12 +30,18 @@ struct MenuBarPopupView<Content: View>: View {
         }
     }
 
+    // Position popup just below the widget
+    // Simply use widgetRect.maxY (bottom of widget in SwiftUI coords) + small gap
+    var popupTopPosition: CGFloat {
+        return widgetRect.maxY + 5
+    }
+
     var body: some View {
         ZStack(alignment: .topTrailing) {
             content
                 .background(Color.black)
                 .cornerRadius(((1.0 - animationValue) * 1) + 40)
-                .padding(.top, foregroundHeight + 5)
+                .padding(.top, popupTopPosition)
                 .offset(x: computedOffset, y: computedYOffset)
                 .shadow(radius: 30)
                 .blur(radius: (1.0 - (0.1 + 0.9 * animationValue)) * 20)

--- a/Barik/Views/MenuBarView.swift
+++ b/Barik/Views/MenuBarView.swift
@@ -52,7 +52,7 @@ struct MenuBarView: View {
             BatteryWidget().environmentObject(config)
 
         case "default.time":
-            TimeWidget(calendarManager: CalendarManager(configProvider: config))
+            TimeWidget(configProvider: config)
                 .environmentObject(config)
             
         case "default.nowplaying":

--- a/Barik/Views/MenuBarView.swift
+++ b/Barik/Views/MenuBarView.swift
@@ -59,6 +59,10 @@ struct MenuBarView: View {
             NowPlayingWidget()
                 .environmentObject(config)
 
+        case "default.weather":
+            WeatherWidget()
+                .environmentObject(config)
+
         case "spacer":
             Spacer().frame(minWidth: 50, maxWidth: .infinity)
 

--- a/Barik/Views/MenuBarView.swift
+++ b/Barik/Views/MenuBarView.swift
@@ -55,7 +55,7 @@ struct MenuBarView: View {
             TimeWidget(configProvider: config)
                 .environmentObject(config)
             
-        case "default.nowplaying":
+        case "default.nowplaying", "default.spotify":
             NowPlayingWidget()
                 .environmentObject(config)
 

--- a/Barik/Widgets/Battery/BatteryManager.swift
+++ b/Barik/Widgets/Battery/BatteryManager.swift
@@ -7,7 +7,7 @@ class BatteryManager: ObservableObject {
     @Published var batteryLevel: Int = 0
     @Published var isCharging: Bool = false
     @Published var isPluggedIn: Bool = false
-    private var timer: Timer?
+    private var runLoopSource: CFRunLoopSource?
 
     init() {
         startMonitoring()
@@ -18,17 +18,33 @@ class BatteryManager: ObservableObject {
     }
 
     private func startMonitoring() {
-        // Update every 1 second.
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) {
-            [weak self] _ in
-            self?.updateBatteryStatus()
+        let context = UnsafeMutableRawPointer(
+            Unmanaged.passUnretained(self).toOpaque())
+
+        runLoopSource = IOPSNotificationCreateRunLoopSource(
+            { context in
+                guard let context = context else { return }
+                let manager = Unmanaged<BatteryManager>.fromOpaque(context)
+                    .takeUnretainedValue()
+                DispatchQueue.main.async {
+                    manager.updateBatteryStatus()
+                }
+            },
+            context
+        )?.takeRetainedValue()
+
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .defaultMode)
         }
+
         updateBatteryStatus()
     }
 
     private func stopMonitoring() {
-        timer?.invalidate()
-        timer = nil
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .defaultMode)
+            runLoopSource = nil
+        }
     }
 
     /// This method updates the battery level and charging state.

--- a/Barik/Widgets/Network/NetworkPopup.swift
+++ b/Barik/Widgets/Network/NetworkPopup.swift
@@ -1,129 +1,221 @@
 import SwiftUI
 
-/// Window displaying detailed network status information.
+/// Window displaying detailed network status information with WiFi controls.
 struct NetworkPopup: View {
     @StateObject private var viewModel = NetworkStatusViewModel()
+    @State private var showOtherNetworks = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            if viewModel.wifiState != .notSupported {
-                HStack(spacing: 8) {
-                    wifiIcon
-                    Text(viewModel.ssid)
-                        .foregroundColor(.white)
-                        .font(.headline)
+        VStack(alignment: .leading, spacing: 0) {
+            // WiFi Toggle Header
+            wifiToggleHeader
+
+            Divider()
+                .background(Color.gray.opacity(0.3))
+                .padding(.vertical, 8)
+
+            if viewModel.isWiFiEnabled {
+                // Known Network (currently connected)
+                if viewModel.ssid != "Not connected" && viewModel.ssid != "No interface" {
+                    knownNetworkSection
+
+                    Divider()
+                        .background(Color.gray.opacity(0.3))
+                        .padding(.vertical, 8)
                 }
 
-                if viewModel.ssid != "Not connected"
-                    && viewModel.ssid != "No interface"
-                {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(
-                            "Signal strength: \(viewModel.wifiSignalStrength.rawValue)"
-                        )
-                        Text("RSSI: \(viewModel.rssi)")
-                        Text("Noise: \(viewModel.noise)")
-                        Text("Channel: \(viewModel.channel)")
-                    }
-                    .font(.subheadline)
-                }
+                // Other Networks
+                otherNetworksSection
+
+                Divider()
+                    .background(Color.gray.opacity(0.3))
+                    .padding(.vertical, 8)
             }
 
-            // Ethernet section
-            if viewModel.ethernetState != .notSupported {
-                HStack(spacing: 8) {
-                    ethernetIcon
-                    Text("Ethernet: \(viewModel.ethernetState.rawValue)")
-                        .foregroundColor(.white)
-                        .font(.headline)
-                }
-            }
+            // WiFi Settings Button
+            wifiSettingsButton
         }
-        .padding(25)
+        .padding(16)
+        .frame(width: 280)
         .background(Color.black)
-    }
-
-    /// Chooses the Wi‑Fi icon based on the status and connection availability.
-    private var wifiIcon: some View {
-        if viewModel.ssid == "Not connected" {
-            return Image(systemName: "wifi.slash")
-                .padding(8)
-                .background(Color.red.opacity(0.8))
-                .clipShape(Circle())
-                .foregroundStyle(.white)
-        }
-        switch viewModel.wifiState {
-        case .connected:
-            return Image(systemName: "wifi")
-                .padding(8)
-                .background(Color.blue.opacity(0.8))
-                .clipShape(Circle())
-                .foregroundStyle(.white)
-        case .connecting:
-            return Image(systemName: "wifi")
-                .padding(8)
-                .background(Color.yellow.opacity(0.8))
-                .clipShape(Circle())
-                .foregroundStyle(.white)
-        case .connectedWithoutInternet:
-            return Image(systemName: "wifi.exclamationmark")
-                .padding(8)
-                .background(Color.yellow.opacity(0.8))
-                .clipShape(Circle())
-                .foregroundStyle(.white)
-        case .disconnected:
-            return Image(systemName: "wifi.slash")
-                .padding(8)
-                .background(Color.gray.opacity(0.8))
-                .clipShape(Circle())
-                .foregroundStyle(.white)
-        case .disabled:
-            return Image(systemName: "wifi.slash")
-                .padding(8)
-                .background(Color.red.opacity(0.8))
-                .clipShape(Circle())
-                .foregroundStyle(.white)
-        case .notSupported:
-            return Image(systemName: "wifi.exclamationmark")
-                .padding(8)
-                .background(Color.gray.opacity(0.8))
-                .clipShape(Circle())
-                .foregroundStyle(.white)
+        .onAppear {
+            if viewModel.isWiFiEnabled {
+                viewModel.scanForNetworks()
+            }
         }
     }
 
-    private var ethernetIcon: some View {
-        switch viewModel.ethernetState {
-        case .connected:
-            return Image(systemName: "network")
-                .padding(8)
-                .background(Color.blue.opacity(0.8))
-                .clipShape(Circle())
-        case .connectedWithoutInternet:
-            return Image(systemName: "network")
-                .padding(8)
-                .background(Color.yellow.opacity(0.8))
-                .clipShape(Circle())
-        case .connecting:
-            return Image(systemName: "network.slash")
-                .padding(8)
-                .background(Color.yellow.opacity(0.8))
-                .clipShape(Circle())
-        case .disconnected:
-            return Image(systemName: "network.slash")
-                .padding(8)
-                .background(Color.gray.opacity(0.8))
-                .clipShape(Circle())
-        case .disabled:
-            return Image(systemName: "network.slash")
-                .padding(8)
-                .background(Color.red.opacity(0.8))
-                .clipShape(Circle())
-        case .notSupported:
-            return Image(systemName: "questionmark.circle")
-                .padding(8)
-                .background(Color.gray.opacity(0.8))
-                .clipShape(Circle())
+    // MARK: - WiFi Toggle Header
+
+    private var wifiToggleHeader: some View {
+        HStack {
+            Text("Wi-Fi")
+                .font(.headline)
+                .foregroundColor(.white)
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { viewModel.isWiFiEnabled },
+                set: { _ in viewModel.toggleWiFi() }
+            ))
+            .toggleStyle(SwitchToggleStyle(tint: .blue))
+            .labelsHidden()
+        }
+        .padding(.bottom, 4)
+    }
+
+    // MARK: - Known Network Section
+
+    private var knownNetworkSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Known Network")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+
+            HStack(spacing: 12) {
+                // WiFi icon with signal strength
+                ZStack {
+                    Circle()
+                        .fill(Color.blue)
+                        .frame(width: 32, height: 32)
+
+                    Image(systemName: wifiIconName(for: viewModel.rssi))
+                        .font(.system(size: 14))
+                        .foregroundColor(.white)
+                }
+
+                Text(viewModel.ssid)
+                    .font(.body)
+                    .foregroundColor(.white)
+
+                Spacer()
+
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 12))
+                    .foregroundColor(.gray)
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Other Networks Section
+
+    private var otherNetworksSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Header with expand/collapse
+            Button(action: {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    showOtherNetworks.toggle()
+                }
+                if showOtherNetworks && viewModel.availableNetworks.isEmpty {
+                    viewModel.scanForNetworks()
+                }
+            }) {
+                HStack {
+                    Text("Other Networks")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+
+                    Spacer()
+
+                    if viewModel.isScanning {
+                        ProgressView()
+                            .scaleEffect(0.7)
+                            .frame(width: 16, height: 16)
+                    } else {
+                        Image(systemName: showOtherNetworks ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 12))
+                            .foregroundColor(.gray)
+                    }
+                }
+            }
+            .buttonStyle(PlainButtonStyle())
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(showOtherNetworks ? Color.blue.opacity(0.3) : Color.clear)
+                    .padding(.horizontal, -8)
+                    .padding(.vertical, -4)
+            )
+
+            // Network list
+            if showOtherNetworks {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(otherNetworks) { network in
+                            networkRow(network)
+                        }
+                    }
+                }
+                .frame(maxHeight: 300)
+            }
+        }
+    }
+
+    private var otherNetworks: [WiFiNetwork] {
+        viewModel.availableNetworks.filter { !$0.isConnected }
+    }
+
+    private func networkRow(_ network: WiFiNetwork) -> some View {
+        Button(action: {
+            viewModel.connectToNetwork(network)
+        }) {
+            HStack(spacing: 12) {
+                Image(systemName: wifiIconName(for: network.rssi))
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .frame(width: 20)
+
+                Text(network.ssid)
+                    .font(.body)
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+
+                Spacer()
+
+                if network.isSecure {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(.gray)
+                }
+            }
+            .padding(.vertical, 6)
+            .padding(.horizontal, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.white.opacity(0.001))
+        )
+        .onHover { hovering in
+            // Could add hover effect here
+        }
+    }
+
+    // MARK: - WiFi Settings Button
+
+    private var wifiSettingsButton: some View {
+        Button(action: {
+            viewModel.openWiFiSettings()
+        }) {
+            Text("Wi-Fi Settings...")
+                .font(.body)
+                .foregroundColor(.white)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    // MARK: - Helpers
+
+    private func wifiIconName(for rssi: Int) -> String {
+        if rssi >= -50 {
+            return "wifi"
+        } else if rssi >= -70 {
+            return "wifi"
+        } else {
+            return "wifi"
         }
     }
 }

--- a/Barik/Widgets/NowPlaying/NowPlayingManager.swift
+++ b/Barik/Widgets/NowPlaying/NowPlayingManager.swift
@@ -283,4 +283,15 @@ final class NowPlayingManager: ObservableObject {
     func nextTrack() {
         NowPlayingProvider.executeCommand { $0.nextTrackCommand }
     }
+
+    /// Opens and activates the music application that is currently playing.
+    func openMusicApp() {
+        guard let song = nowPlaying else { return }
+        if let app = NSWorkspace.shared.runningApplications.first(where: {
+            $0.localizedName == song.appName
+        }),
+        let bundleURL = app.bundleURL {
+            NSWorkspace.shared.open(bundleURL)
+        }
+    }
 }

--- a/Barik/Widgets/NowPlaying/NowPlayingPopup.swift
+++ b/Barik/Widgets/NowPlaying/NowPlayingPopup.swift
@@ -66,6 +66,7 @@ private struct NowPlayingVerticalPopup: View {
                     : nil
                 )
                 .animation(.smooth(duration: 0.5, extraBounce: 0.4), value: song.state == .paused)
+                .onTapGesture { playingManager.openMusicApp() }
 
                 VStack(alignment: .center) {
                     Text(song.title)
@@ -77,6 +78,7 @@ private struct NowPlayingVerticalPopup: View {
                         .font(.system(size: 15))
                         .fontWeight(.light)
                 }
+                .onTapGesture { playingManager.openMusicApp() }
 
                 HStack {
                     Text(timeString(from: position))
@@ -135,6 +137,7 @@ struct NowPlayingHorizontalPopup: View {
                         : nil
                     )
                     .animation(.smooth(duration: 0.5, extraBounce: 0.4), value: song.state == .paused)
+                    .onTapGesture { playingManager.openMusicApp() }
 
                     VStack(alignment: .leading, spacing: 0) {
                         Text(song.title)
@@ -147,6 +150,7 @@ struct NowPlayingHorizontalPopup: View {
                     }
                     .padding(.trailing, 8)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .onTapGesture { playingManager.openMusicApp() }
                 }
 
                 HStack {

--- a/Barik/Widgets/NowPlaying/NowPlayingWidget.swift
+++ b/Barik/Widgets/NowPlaying/NowPlayingWidget.swift
@@ -26,6 +26,7 @@ struct NowPlayingWidget: View {
 
                 // Visible content with fixed animated width.
                 VisibleNowPlayingContent(song: song, width: animatedWidth)
+                    .contentShape(Rectangle())
                     .onTapGesture {
                         MenuBarPopup.show(rect: widgetFrame, id: "nowplaying") {
                             NowPlayingPopup(configProvider: configProvider)

--- a/Barik/Widgets/Spaces/Yabai/YabaiProvider.swift
+++ b/Barik/Widgets/Spaces/Yabai/YabaiProvider.swift
@@ -1,8 +1,148 @@
+import Combine
 import Foundation
 
-class YabaiSpacesProvider: SpacesProvider, SwitchableSpacesProvider {
+class YabaiSpacesProvider: SpacesProvider, SwitchableSpacesProvider, EventBasedSpacesProvider {
     typealias SpaceType = YabaiSpace
     let executablePath = ConfigManager.shared.config.yabai.path
+
+    // MARK: - Event-Based Provider Support
+
+    private let spacesSubject = PassthroughSubject<SpaceEvent, Never>()
+    var spacesPublisher: AnyPublisher<SpaceEvent, Never> {
+        spacesSubject.eraseToAnyPublisher()
+    }
+
+    private var socketFileDescriptor: Int32 = -1
+    private var socketPath = "/tmp/barik-yabai.sock"
+    private var isObserving = false
+    private var socketQueue = DispatchQueue(label: "com.barik.yabai.socket", qos: .userInitiated)
+
+    func startObserving() {
+        guard !isObserving else { return }
+        isObserving = true
+
+        // Send initial state
+        if let spaces = getSpacesWithWindows() {
+            let anySpaces = spaces.map { AnySpace($0) }
+            spacesSubject.send(.initialState(anySpaces))
+        }
+
+        // Start socket listener
+        socketQueue.async { [weak self] in
+            self?.startSocketListener()
+        }
+    }
+
+    func stopObserving() {
+        isObserving = false
+        if socketFileDescriptor >= 0 {
+            close(socketFileDescriptor)
+            socketFileDescriptor = -1
+        }
+        unlink(socketPath)
+    }
+
+    private func startSocketListener() {
+        // Remove existing socket file
+        unlink(socketPath)
+
+        // Create Unix domain socket
+        socketFileDescriptor = socket(AF_UNIX, SOCK_DGRAM, 0)
+        guard socketFileDescriptor >= 0 else {
+            print("Failed to create socket")
+            return
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathSize = MemoryLayout.size(ofValue: addr.sun_path)
+        socketPath.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let pathBytes = UnsafeMutableRawPointer(pathPtr)
+                    .assumingMemoryBound(to: CChar.self)
+                strncpy(pathBytes, ptr, pathSize - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { addrPtr in
+            addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                bind(socketFileDescriptor, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+
+        guard bindResult >= 0 else {
+            print("Failed to bind socket: \(String(cString: strerror(errno)))")
+            close(socketFileDescriptor)
+            socketFileDescriptor = -1
+            return
+        }
+
+        // Listen for messages
+        var buffer = [CChar](repeating: 0, count: 1024)
+        while isObserving && socketFileDescriptor >= 0 {
+            let bytesRead = recv(socketFileDescriptor, &buffer, buffer.count - 1, 0)
+            if bytesRead > 0 {
+                buffer[bytesRead] = 0
+                let message = String(cString: buffer)
+                handleSocketMessage(message.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+    }
+
+    private func handleSocketMessage(_ message: String) {
+        // Parse message format: "event_type:data" or just "event_type"
+        let parts = message.split(separator: ":", maxSplits: 1)
+        let eventType = String(parts[0])
+        let data = parts.count > 1 ? String(parts[1]) : nil
+
+        switch eventType {
+        case "space_changed":
+            if let spaceId = data {
+                spacesSubject.send(.focusChanged(spaceId))
+            } else {
+                // Fallback: query current focused space
+                refreshSpaces()
+            }
+
+        case "window_focused", "window_created", "window_destroyed", "window_moved":
+            // For window events, refresh the windows for affected space
+            if let spaceIdStr = data, let spaces = getSpacesWithWindows() {
+                if let space = spaces.first(where: { String($0.id) == spaceIdStr }) {
+                    let windows = space.windows.map { AnyWindow($0) }
+                    spacesSubject.send(.windowsUpdated(spaceIdStr, windows))
+                }
+            } else {
+                refreshSpaces()
+            }
+
+        case "space_created":
+            if let spaceId = data {
+                spacesSubject.send(.spaceCreated(spaceId))
+            } else {
+                refreshSpaces()
+            }
+
+        case "space_destroyed":
+            if let spaceId = data {
+                spacesSubject.send(.spaceDestroyed(spaceId))
+            } else {
+                refreshSpaces()
+            }
+
+        default:
+            // Unknown event, refresh all
+            refreshSpaces()
+        }
+    }
+
+    private func refreshSpaces() {
+        if let spaces = getSpacesWithWindows() {
+            let anySpaces = spaces.map { AnySpace($0) }
+            spacesSubject.send(.initialState(anySpaces))
+        }
+    }
+
+    // MARK: - Original Provider Methods
 
     private func runYabaiCommand(arguments: [String]) -> Data? {
         let process = Process()

--- a/Barik/Widgets/Time+Calendar/CalendarPopup.swift
+++ b/Barik/Widgets/Time+Calendar/CalendarPopup.swift
@@ -19,7 +19,8 @@ struct CalendarPopup: View {
             },
             box: { CalendarBoxPopup() },
             vertical: { CalendarVerticalPopup(calendarManager) },
-            horizontal: { CalendarHorizontalPopup(calendarManager) }
+            horizontal: { CalendarHorizontalPopup(calendarManager) },
+            dayView: { CalendarDayViewPopup(calendarManager) }
         )
         .onAppear {
             if let variantString = configProvider.config["popup"]?
@@ -357,6 +358,364 @@ private struct EventRow: View {
     }
 }
 
+// MARK: - Day View Popup (Mac Sidebar Style)
+
+struct CalendarDayViewPopup: View {
+    let calendarManager: CalendarManager
+
+    init(_ calendarManager: CalendarManager) {
+        self.calendarManager = calendarManager
+    }
+
+    private let hourHeight: CGFloat = 44
+    private let startHour: Int = 8
+    private let endHour: Int = 18
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            // Left side: Today
+            TodayColumnView(startHour: startHour, endHour: endHour, hourHeight: hourHeight, events: calendarManager.todaysEvents)
+
+            // Divider
+            Rectangle()
+                .fill(Color.white.opacity(0.1))
+                .frame(width: 1)
+
+            // Right side: Tomorrow
+            TomorrowColumnView(startHour: startHour, endHour: endHour, hourHeight: hourHeight, events: calendarManager.tomorrowsEvents)
+        }
+        .padding(20)
+        .fontWeight(.semibold)
+        .foregroundStyle(.white)
+    }
+}
+
+private struct TodayColumnView: View {
+    let startHour: Int
+    let endHour: Int
+    let hourHeight: CGFloat
+    let events: [EKEvent]
+
+    @State private var currentTime = Date()
+    private let timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+
+    private var dayOfWeek: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE"
+        return formatter.string(from: Date()).uppercased()
+    }
+
+    private var dayNumber: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "d"
+        return formatter.string(from: Date())
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header: Day of week + date
+            VStack(alignment: .leading, spacing: 2) {
+                Text(dayOfWeek)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(Color(red: 1.0, green: 0.4, blue: 0.4))
+                Text(dayNumber)
+                    .font(.system(size: 34, weight: .light))
+            }
+            .padding(.bottom, 15)
+
+            // Time slots with current time indicator
+            ZStack(alignment: .topLeading) {
+                // Hour labels and lines
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(startHour..<endHour, id: \.self) { hour in
+                        HStack(alignment: .top, spacing: 8) {
+                            Text(formatHour(hour))
+                                .font(.system(size: 12))
+                                .foregroundColor(.gray)
+                                .frame(width: 24, alignment: .trailing)
+
+                            Rectangle()
+                                .fill(Color.white.opacity(0.15))
+                                .frame(height: 1)
+                                .frame(maxWidth: .infinity)
+                        }
+                        .frame(height: hourHeight)
+                    }
+                }
+
+                // Current time indicator
+                currentTimeIndicator
+            }
+            .frame(width: 120)
+        }
+        .onReceive(timer) { _ in
+            currentTime = Date()
+        }
+    }
+
+    private var currentTimeIndicator: some View {
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: currentTime)
+        let minute = calendar.component(.minute, from: currentTime)
+
+        let hourOffset = hour - startHour
+        let minuteOffset = CGFloat(minute) / 60.0
+        let yPosition = CGFloat(hourOffset) * hourHeight + minuteOffset * hourHeight
+
+        return Group {
+            if hour >= startHour && hour < endHour {
+                HStack(spacing: 0) {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: 8, height: 8)
+                    Rectangle()
+                        .fill(Color.red)
+                        .frame(height: 1)
+                }
+                .offset(x: 28, y: yPosition - 4)
+            }
+        }
+    }
+
+    private func formatHour(_ hour: Int) -> String {
+        let h = hour > 12 ? hour - 12 : hour
+        return "\(h)"
+    }
+}
+
+private struct TomorrowColumnView: View {
+    let startHour: Int
+    let endHour: Int
+    let hourHeight: CGFloat
+    let events: [EKEvent]
+
+    @State private var showAllDayEvents = false
+
+    private var allDayEvents: [EKEvent] {
+        events.filter { $0.isAllDay }
+    }
+
+    private var timedEvents: [EKEvent] {
+        events.filter { !$0.isAllDay }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header: TOMORROW
+            VStack(alignment: .leading, spacing: 6) {
+                Text("TOMORROW")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.gray)
+
+                // All-day events badge (clickable)
+                if !allDayEvents.isEmpty {
+                    allDayEventsBadge
+                        .onTapGesture {
+                            withAnimation(.smooth(duration: 0.2)) {
+                                showAllDayEvents.toggle()
+                            }
+                        }
+
+                    // Expanded all-day events list
+                    if showAllDayEvents {
+                        allDayEventsList
+                    }
+                }
+            }
+            .padding(.bottom, 15)
+
+            // Time slots with events
+            ZStack(alignment: .topLeading) {
+                // Hour labels
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(startHour..<endHour, id: \.self) { hour in
+                        HStack(alignment: .top, spacing: 8) {
+                            Text(formatHour(hour))
+                                .font(.system(size: 12))
+                                .foregroundColor(.gray)
+                                .frame(width: 24, alignment: .trailing)
+
+                            Rectangle()
+                                .fill(Color.white.opacity(0.15))
+                                .frame(height: 1)
+                                .frame(maxWidth: .infinity)
+                        }
+                        .frame(height: hourHeight)
+                    }
+                }
+
+                // Events overlay
+                eventsOverlay
+            }
+            .frame(width: 200)
+        }
+    }
+
+    private var allDayEventsBadge: some View {
+        HStack(spacing: 4) {
+            // Show colored dots for first 3 calendars
+            HStack(spacing: -4) {
+                ForEach(Array(allDayEvents.prefix(3).enumerated()), id: \.offset) { _, event in
+                    Circle()
+                        .fill(Color(event.calendar.cgColor))
+                        .frame(width: 14, height: 14)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.black, lineWidth: 2)
+                        )
+                }
+            }
+
+            Text("\(allDayEvents.count) all-day event\(allDayEvents.count == 1 ? "" : "s")")
+                .font(.system(size: 12))
+                .foregroundColor(.white)
+
+            Image(systemName: showAllDayEvents ? "chevron.up" : "chevron.down")
+                .font(.system(size: 10))
+                .foregroundColor(.gray)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.white.opacity(0.1))
+        .cornerRadius(6)
+        .contentShape(Rectangle())
+    }
+
+    private var allDayEventsList: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(allDayEvents, id: \.eventIdentifier) { event in
+                HStack(spacing: 6) {
+                    Rectangle()
+                        .fill(Color(event.calendar.cgColor))
+                        .frame(width: 3, height: 16)
+                        .cornerRadius(1.5)
+
+                    Text(event.title ?? "Untitled")
+                        .font(.system(size: 12))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                }
+                .padding(.vertical, 2)
+            }
+        }
+        .padding(.top, 6)
+        .transition(.opacity.combined(with: .move(edge: .top)))
+    }
+
+    private var eventsOverlay: some View {
+        let calendar = Calendar.current
+        let visibleEvents = timedEvents.filter { event in
+            let hour = calendar.component(.hour, from: event.startDate)
+            return hour >= startHour && hour < endHour
+        }
+
+        // Group overlapping events
+        let groupedEvents = groupOverlappingEvents(visibleEvents)
+
+        return ZStack(alignment: .topLeading) {
+            ForEach(groupedEvents, id: \.0.eventIdentifier) { event, column, totalColumns in
+                eventBlock(event: event, column: column, totalColumns: totalColumns)
+            }
+
+            // "X more events" indicator if there are events outside visible range
+            let hiddenCount = timedEvents.count - visibleEvents.count
+            if hiddenCount > 0 {
+                Text("\(hiddenCount) more event\(hiddenCount == 1 ? "" : "s")")
+                    .font(.system(size: 11))
+                    .foregroundColor(.gray)
+                    .offset(x: 36, y: CGFloat(endHour - startHour) * hourHeight - 20)
+            }
+        }
+    }
+
+    private func eventBlock(event: EKEvent, column: Int, totalColumns: Int) -> some View {
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: event.startDate)
+        let minute = calendar.component(.minute, from: event.startDate)
+
+        let hourOffset = hour - startHour
+        let minuteOffset = CGFloat(minute) / 60.0
+        let yPosition = CGFloat(hourOffset) * hourHeight + minuteOffset * hourHeight
+
+        // Calculate duration for height
+        let duration = event.endDate.timeIntervalSince(event.startDate) / 3600.0
+        let height = max(CGFloat(duration) * hourHeight - 2, 20)
+
+        // Calculate width based on overlapping events
+        let availableWidth: CGFloat = 160
+        let eventWidth = (availableWidth / CGFloat(totalColumns)) - 2
+        let xOffset: CGFloat = 36 + CGFloat(column) * (eventWidth + 2)
+
+        return HStack(spacing: 0) {
+            Rectangle()
+                .fill(Color(event.calendar.cgColor))
+                .frame(width: 3)
+
+            Text(event.title ?? "")
+                .font(.system(size: 11))
+                .lineLimit(height > 30 ? 2 : 1)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+        }
+        .frame(width: eventWidth, height: height, alignment: .leading)
+        .background(Color(event.calendar.cgColor).opacity(0.25))
+        .cornerRadius(4)
+        .offset(x: xOffset, y: yPosition)
+    }
+
+    private func groupOverlappingEvents(_ events: [EKEvent]) -> [(EKEvent, Int, Int)] {
+        guard !events.isEmpty else { return [] }
+
+        var result: [(EKEvent, Int, Int)] = []
+        var groups: [[EKEvent]] = []
+
+        let sortedEvents = events.sorted { $0.startDate < $1.startDate }
+
+        for event in sortedEvents {
+            var placed = false
+            for i in groups.indices {
+                let groupEnd = groups[i].map { $0.endDate }.max() ?? Date.distantPast
+                if event.startDate >= groupEnd {
+                    groups[i].append(event)
+                    placed = true
+                    break
+                }
+            }
+            if !placed {
+                groups.append([event])
+            }
+        }
+
+        // Flatten with column info
+        for event in sortedEvents {
+            var column = 0
+            var overlappingCount = 1
+
+            for (idx, group) in groups.enumerated() {
+                if group.contains(where: { $0.eventIdentifier == event.eventIdentifier }) {
+                    column = idx
+                    // Count how many groups overlap with this event
+                    overlappingCount = groups.filter { group in
+                        group.contains { otherEvent in
+                            !(event.endDate <= otherEvent.startDate || event.startDate >= otherEvent.endDate)
+                        }
+                    }.count
+                    break
+                }
+            }
+
+            result.append((event, column, max(overlappingCount, groups.count)))
+        }
+
+        return result
+    }
+
+    private func formatHour(_ hour: Int) -> String {
+        let h = hour > 12 ? hour - 12 : hour
+        return "\(h)"
+    }
+}
+
 struct CalendarPopup_Previews: PreviewProvider {
     var configProvider: ConfigProvider = ConfigProvider(config: ConfigData())
     var calendarManager: CalendarManager
@@ -381,5 +740,9 @@ struct CalendarPopup_Previews: PreviewProvider {
             .background(Color.black)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Horizontal")
+        CalendarDayViewPopup(calendarManager)
+            .background(Color.black)
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Day View")
     }
 }

--- a/Barik/Widgets/Time+Calendar/TimeWidget.swift
+++ b/Barik/Widgets/Time+Calendar/TimeWidget.swift
@@ -18,7 +18,11 @@ struct TimeWidget: View {
     }
 
     @State private var currentTime = Date()
-    let calendarManager: CalendarManager
+    @StateObject private var calendarManager: CalendarManager
+
+    init(configProvider: ConfigProvider) {
+        _calendarManager = StateObject(wrappedValue: CalendarManager(configProvider: configProvider))
+    }
 
     @State private var rect = CGRect()
 
@@ -103,10 +107,9 @@ struct TimeWidget: View {
 struct TimeWidget_Previews: PreviewProvider {
     static var previews: some View {
         let provider = ConfigProvider(config: ConfigData())
-        let manager = CalendarManager(configProvider: provider)
 
         ZStack {
-            TimeWidget(calendarManager: manager)
+            TimeWidget(configProvider: provider)
                 .environmentObject(provider)
         }.frame(width: 500, height: 100)
     }

--- a/Barik/Widgets/Time+Calendar/TimeWidget.swift
+++ b/Barik/Widgets/Time+Calendar/TimeWidget.swift
@@ -8,6 +8,7 @@ struct TimeWidget: View {
 
     var format: String { config["format"]?.stringValue ?? "E d, J:mm" }
     var timeZone: String? { config["time-zone"]?.stringValue }
+    var clickAction: String { config["click-action"]?.stringValue ?? "calendar" }
 
     var calendarFormat: String {
         calendarConfig?["format"]?.stringValue ?? "J:mm"
@@ -57,10 +58,17 @@ struct TimeWidget: View {
         .background(.black.opacity(0.001))
         .monospacedDigit()
         .onTapGesture {
-            MenuBarPopup.show(rect: rect, id: "calendar") {
-                CalendarPopup(
-                    calendarManager: calendarManager,
-                    configProvider: configProvider)
+            switch clickAction {
+            case "notification-center":
+                SystemUIHelper.openNotificationCenter()
+            case "calendar":
+                fallthrough
+            default:
+                MenuBarPopup.show(rect: rect, id: "calendar") {
+                    CalendarPopup(
+                        calendarManager: calendarManager,
+                        configProvider: configProvider)
+                }
             }
         }
     }

--- a/Barik/Widgets/Time+Calendar/TimeWidget.swift
+++ b/Barik/Widgets/Time+Calendar/TimeWidget.swift
@@ -55,7 +55,7 @@ struct TimeWidget: View {
         )
         .experimentalConfiguration(cornerRadius: 15)
         .frame(maxHeight: .infinity)
-        .background(.black.opacity(0.001))
+        .contentShape(Rectangle())
         .monospacedDigit()
         .onTapGesture {
             switch clickAction {

--- a/Barik/Widgets/Time+Calendar/TimeWidget.swift
+++ b/Barik/Widgets/Time+Calendar/TimeWidget.swift
@@ -61,8 +61,6 @@ struct TimeWidget: View {
             switch clickAction {
             case "notification-center":
                 SystemUIHelper.openNotificationCenter()
-            case "calendar":
-                fallthrough
             default:
                 MenuBarPopup.show(rect: rect, id: "calendar") {
                     CalendarPopup(

--- a/Barik/Widgets/Weather/WeatherPopup.swift
+++ b/Barik/Widgets/Weather/WeatherPopup.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+struct WeatherPopup: View {
+    @ObservedObject private var weatherManager = WeatherManager.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let weather = weatherManager.currentWeather {
+                // Header: Location + Current Weather
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 4) {
+                            Text(weatherManager.locationName ?? "Current Location")
+                                .font(.system(size: 14, weight: .medium))
+                            Image(systemName: "location.fill")
+                                .font(.system(size: 8))
+                                .opacity(0.6)
+                        }
+                        Text(weather.temperature)
+                            .font(.system(size: 48, weight: .regular))
+                    }
+
+                    Spacer()
+
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Image(systemName: weather.symbolName)
+                            .symbolRenderingMode(.multicolor)
+                            .font(.system(size: 28))
+                        Text(weather.condition)
+                            .font(.system(size: 13))
+                            .opacity(0.8)
+                        if let high = weatherManager.highTemp, let low = weatherManager.lowTemp {
+                            Text("H:\(high) L:\(low)")
+                                .font(.system(size: 12))
+                                .opacity(0.6)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+                .padding(.bottom, 15)
+
+                Divider()
+                    .background(Color.white.opacity(0.2))
+
+                // Precipitation indicator (if raining)
+                if let precipitation = weatherManager.precipitation, precipitation > 0 {
+                    HStack(spacing: 8) {
+                        Image(systemName: "umbrella.fill")
+                            .font(.system(size: 14))
+                        Text("\(Int(precipitation * 100))% chance of rain")
+                            .font(.system(size: 13))
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+
+                    Divider()
+                        .background(Color.white.opacity(0.2))
+                }
+
+                // Hourly Forecast
+                if !weatherManager.hourlyForecast.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 20) {
+                            ForEach(weatherManager.hourlyForecast.prefix(6), id: \.time) { hour in
+                                VStack(spacing: 8) {
+                                    Text(hour.timeLabel)
+                                        .font(.system(size: 12, weight: .medium))
+                                        .opacity(0.8)
+                                    Image(systemName: hour.symbolName)
+                                        .symbolRenderingMode(.multicolor)
+                                        .font(.system(size: 20))
+                                    if let precip = hour.precipitationProbability, precip > 0 {
+                                        Text("\(precip)%")
+                                            .font(.system(size: 10))
+                                            .foregroundColor(.cyan)
+                                    }
+                                    Text(hour.temperature)
+                                        .font(.system(size: 14, weight: .medium))
+                                }
+                                .frame(width: 50)
+                            }
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 15)
+                    }
+
+                    Divider()
+                        .background(Color.white.opacity(0.2))
+                }
+
+                // Open Weather button
+                Button(action: {
+                    SystemUIHelper.openWeatherApp()
+                }) {
+                    HStack {
+                        Text("Open Weather")
+                            .font(.system(size: 13))
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12))
+                            .opacity(0.5)
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .background(Color.white.opacity(0.001))
+                .onHover { hovering in
+                    if hovering {
+                        NSCursor.pointingHand.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+
+            } else {
+                // Loading state
+                VStack(spacing: 12) {
+                    ProgressView()
+                    Text("Loading weather...")
+                        .font(.system(size: 13))
+                        .opacity(0.6)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(40)
+            }
+        }
+        .frame(width: 280)
+        .background(Color.black)
+    }
+}
+
+struct WeatherPopup_Previews: PreviewProvider {
+    static var previews: some View {
+        WeatherPopup()
+            .background(Color.black)
+    }
+}

--- a/Barik/Widgets/Weather/WeatherWidget.swift
+++ b/Barik/Widgets/Weather/WeatherWidget.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+import CoreLocation
+
+/// Weather widget that displays current weather using Open-Meteo API
+struct WeatherWidget: View {
+    @StateObject private var weatherManager = WeatherManager.shared
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if let weather = weatherManager.currentWeather {
+                Image(systemName: weather.symbolName)
+                    .symbolRenderingMode(.multicolor)
+                Text(weather.temperature)
+                    .fontWeight(.semibold)
+            } else {
+                Image(systemName: "cloud.sun")
+                    .symbolRenderingMode(.multicolor)
+                if weatherManager.isLoading {
+                    ProgressView()
+                        .scaleEffect(0.5)
+                }
+            }
+        }
+        .font(.headline)
+        .foregroundStyle(.foregroundOutside)
+        .shadow(color: .foregroundShadowOutside, radius: 3)
+        .experimentalConfiguration(cornerRadius: 15)
+        .frame(maxHeight: .infinity)
+        .background(.black.opacity(0.001))
+        .onTapGesture {
+            SystemUIHelper.openWeatherDropdown()
+        }
+        .onAppear {
+            weatherManager.startUpdating()
+        }
+    }
+}
+
+// MARK: - Weather Data Model
+
+struct CurrentWeather {
+    let temperature: String
+    let symbolName: String
+    let condition: String
+}
+
+// MARK: - Open-Meteo API Response
+
+struct OpenMeteoResponse: Codable {
+    let currentWeather: OpenMeteoCurrentWeather
+
+    enum CodingKeys: String, CodingKey {
+        case currentWeather = "current_weather"
+    }
+}
+
+struct OpenMeteoCurrentWeather: Codable {
+    let temperature: Double
+    let weathercode: Int
+}
+
+// MARK: - Weather Manager
+
+@MainActor
+final class WeatherManager: NSObject, ObservableObject {
+    static let shared = WeatherManager()
+
+    @Published private(set) var currentWeather: CurrentWeather?
+    @Published private(set) var isLoading = false
+
+    private let locationManager = CLLocationManager()
+    private var lastLocation: CLLocation?
+    private var updateTimer: Timer?
+
+    override private init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
+    }
+
+    func startUpdating() {
+        if locationManager.authorizationStatus == .notDetermined {
+            locationManager.requestWhenInUseAuthorization()
+        }
+        locationManager.startUpdatingLocation()
+
+        // Update every 15 minutes
+        updateTimer?.invalidate()
+        updateTimer = Timer.scheduledTimer(withTimeInterval: 900, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.fetchWeather()
+            }
+        }
+    }
+
+    func stopUpdating() {
+        locationManager.stopUpdatingLocation()
+        updateTimer?.invalidate()
+        updateTimer = nil
+    }
+
+    private func fetchWeather() {
+        guard let location = lastLocation else { return }
+
+        isLoading = true
+
+        Task {
+            do {
+                let lat = location.coordinate.latitude
+                let lon = location.coordinate.longitude
+                let urlString = "https://api.open-meteo.com/v1/forecast?latitude=\(lat)&longitude=\(lon)&current_weather=true&temperature_unit=fahrenheit"
+
+                guard let url = URL(string: urlString) else {
+                    isLoading = false
+                    return
+                }
+
+                let (data, _) = try await URLSession.shared.data(from: url)
+                let response = try JSONDecoder().decode(OpenMeteoResponse.self, from: data)
+
+                let temp = Int(response.currentWeather.temperature.rounded())
+                let symbol = symbolName(for: response.currentWeather.weathercode)
+                let condition = conditionName(for: response.currentWeather.weathercode)
+
+                self.currentWeather = CurrentWeather(
+                    temperature: "\(temp)°F",
+                    symbolName: symbol,
+                    condition: condition
+                )
+            } catch {
+                print("Weather fetch error: \(error)")
+            }
+            isLoading = false
+        }
+    }
+
+    /// Maps Open-Meteo weather codes to SF Symbols
+    private func symbolName(for code: Int) -> String {
+        switch code {
+        case 0:
+            return "sun.max.fill"
+        case 1, 2:
+            return "cloud.sun.fill"
+        case 3:
+            return "cloud.fill"
+        case 45, 48:
+            return "cloud.fog.fill"
+        case 51, 53, 55, 56, 57:
+            return "cloud.drizzle.fill"
+        case 61, 63, 65, 66, 67:
+            return "cloud.rain.fill"
+        case 71, 73, 75, 77:
+            return "cloud.snow.fill"
+        case 80, 81, 82:
+            return "cloud.heavyrain.fill"
+        case 85, 86:
+            return "cloud.snow.fill"
+        case 95, 96, 99:
+            return "cloud.bolt.rain.fill"
+        default:
+            return "cloud.fill"
+        }
+    }
+
+    /// Maps Open-Meteo weather codes to condition names
+    private func conditionName(for code: Int) -> String {
+        switch code {
+        case 0:
+            return "Clear"
+        case 1:
+            return "Mainly Clear"
+        case 2:
+            return "Partly Cloudy"
+        case 3:
+            return "Overcast"
+        case 45, 48:
+            return "Foggy"
+        case 51, 53, 55:
+            return "Drizzle"
+        case 56, 57:
+            return "Freezing Drizzle"
+        case 61, 63, 65:
+            return "Rain"
+        case 66, 67:
+            return "Freezing Rain"
+        case 71, 73, 75:
+            return "Snow"
+        case 77:
+            return "Snow Grains"
+        case 80, 81, 82:
+            return "Rain Showers"
+        case 85, 86:
+            return "Snow Showers"
+        case 95:
+            return "Thunderstorm"
+        case 96, 99:
+            return "Thunderstorm with Hail"
+        default:
+            return "Unknown"
+        }
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension WeatherManager: CLLocationManagerDelegate {
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+
+        Task { @MainActor in
+            // Only update if location changed significantly (1km)
+            if lastLocation == nil || lastLocation!.distance(from: location) > 1000 {
+                lastLocation = location
+                fetchWeather()
+            }
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("Location error: \(error)")
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        if manager.authorizationStatus == .authorized ||
+            manager.authorizationStatus == .authorizedAlways {
+            manager.startUpdatingLocation()
+        }
+    }
+}
+
+struct WeatherWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            WeatherWidget()
+        }.frame(width: 100, height: 50)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ A fork of [barik](https://github.com/mocki-toki/barik) with active improvements 
 
 ## Improvements over barik
 
-- **Event-driven updates** - Replaced polling with event-driven notifications for music playback and space changes. More efficient and responsive.
+- **Drastically reduced CPU usage** - Replaced polling with event-driven notifications for music playback and space changes
 - **Enhanced calendar popup** - Day view with event selection and detailed event information
 - **Click to open music player** - Click on album art, song title, or artist in the now playing popup to open Spotify or Apple Music
+- **Improved WiFi popup** - macOS-style controls and better network information
+- **New weather popup** - Hourly forecast using Open-Meteo API
 - **Fixed popup positioning** - Consistent popup positioning across all widgets
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
-**NOTICE**: Unfortunately, I don’t have much free time to actively maintain this project. If you like the project but are not satisfied with its current state, you can explore the many forks or create your own. Even if you’re unfamiliar with **Swift**, tools like **Claude Code** and **Codex** can effectively help implement projects like this. This is a great opportunity to tailor **barik** to your needs and make it exactly the way you’d like.
-
-----
-
 <p align="center" dir="auto">
-  <img src="resources/header-image.png" alt="Barik"">
-  <p align="center" dir="auto">
-    <a href="LICENSE">
-      <img alt="License Badge" src="https://img.shields.io/github/license/mocki-toki/barik.svg?color=green" style="max-width: 100%;">
-    </a>
-    <a href="https://github.com/mocki-toki/barik/issues">
-      <img alt="Issues Badge" src="https://img.shields.io/github/issues/mocki-toki/barik.svg?color=green" style="max-width: 100%;">
-    </a>
-    <a href="CHANGELOG.md">
-      <img alt="Changelog Badge" src="https://img.shields.io/badge/view-changelog-green.svg" style="max-width: 100%;">
-    </a>
-    <a href="https://github.com/mocki-toki/barik/releases">
-      <img alt="GitHub Downloads (all assets, all releases)" src="https://img.shields.io/github/downloads/mocki-toki/barik/total">
-    </a>
-  </p>
+  <img src="resources/header-image.png" alt="Barik">
 </p>
+
+# barik-but-better
+
+A fork of [barik](https://github.com/mocki-toki/barik) with active improvements and new features.
+
+## Improvements over barik
+
+- **Event-driven updates** - Replaced polling with event-driven notifications for music playback and space changes. More efficient and responsive.
+- **Enhanced calendar popup** - Day view with event selection and detailed event information
+- **Click to open music player** - Click on album art, song title, or artist in the now playing popup to open Spotify or Apple Music
+- **Fixed popup positioning** - Consistent popup positioning across all widgets
+
+---
 
 **barik** is a lightweight macOS menu bar replacement. If you use [**yabai**](https://github.com/koekeishiya/yabai) or [**AeroSpace**](https://github.com/nikitabobko/AeroSpace) for tiling WM, you can display the current space in a sleek macOS-style panel with smooth animations. This makes it easy to see which number to press to switch spaces.
 


### PR DESCRIPTION
## Summary
- Add `"default.nowplaying"` back to the default widget displayed list — it was dropped when the widget was renamed from `"default.spotify"`
- Accept `"default.spotify"` as an alias in `MenuBarView` so existing user configs still work

## Test plan
- [ ] Fresh install: verify the now playing widget appears in the menu bar by default
- [ ] Existing config with `"default.spotify"`: verify the widget renders correctly instead of showing a red error label

🤖 Generated with [Claude Code](https://claude.com/claude-code)